### PR TITLE
Implemented reconciliation for Scale subresource status.

### DIFF
--- a/controllers/hvpa_controller.go
+++ b/controllers/hvpa_controller.go
@@ -1104,7 +1104,8 @@ func (r *HvpaReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	log.V(1).Info("Reconciling", "hvpa", instance.GetName())
 
-	r.reconcileScaleStatus(instance)
+	hvpa := instance.DeepCopy()
+	r.reconcileScaleStatus(hvpa)
 
 	if instance.GetDeletionTimestamp() != nil {
 		if finalizers := sets.NewString(instance.Finalizers...); finalizers.Has(deleteFinalizerName) {
@@ -1161,7 +1162,6 @@ func (r *HvpaReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
-	hvpa := instance.DeepCopy()
 	if len(*blockedScaling) != 0 {
 		hvpa.Status.LastBlockedScaling = *blockedScaling
 	}

--- a/controllers/hvpa_controller.go
+++ b/controllers/hvpa_controller.go
@@ -195,10 +195,10 @@ func (r *HvpaReconciler) getScaleStatusFromTarget(instance *autoscalingv1alpha1.
 	// TODO use the Scale subresource if possible
 	if replicas, found, err := unstructured.NestedInt64(target.Object, "status", "replicas"); err != nil {
 		log.Error(err, "Not able to get the status replicas from target.", "Will skip", instance.Name)
-		return nil, nil, err
+		return selector, nil, err
 	} else if !found {
 		log.V(2).Info("Target doesn't have status replicas", "will skip HVPA", instance.Name)
-		return nil, nil, err
+		return selector, nil, err
 	} else {
 		statusReplicas := int32(replicas)
 		return selector, &statusReplicas, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Implemented reconciliation for Scale subresource status.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Does not implement the handling for `spec.Replicas` yet.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
