### PR TITLE
Use default port allocation for metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 		enableLeaderElection  bool
 		enableDetailedMetrics bool
 	)
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-addr", ":9569", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableDetailedMetrics, "enable-detailed-metrics", false,


### PR DESCRIPTION
**What this PR does / why we need it**:
The hvpa-controller is now listed as an exporter on the [prometheus exporter wiki](https://github.com/prometheus/prometheus/wiki/Default-port-allocations). This PR changes the default port value to the value in the wiki.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Change default port to `9569`
```
