### PR TITLE
Override vpaWeight if HPA is not maxed out and oomkill still happens

### DIFF
--- a/controllers/hvpa_controller.go
+++ b/controllers/hvpa_controller.go
@@ -762,6 +762,10 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 	overrideScaleUpStabilization := hvpa.Status.OverrideScaleUpStabilization
 	if overrideScaleUpStabilization {
 		log.V(2).Info("VPA", "will override last scale time in case of scale up", overrideScaleUpStabilization)
+		if vpaWeight == 0 {
+			log.V(2).Info("VPA", "will override vpaWeight from 0 to 1")
+			vpaWeight = 1
+		}
 	}
 	if lastScaleTime == nil {
 		lastScaleTime = &metav1.Time{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if `vpaWeight` is 0, there can be a case when the pods can get OOMkilled, and HPA doesn't recommend scale out because metrics couldn't be collected for the crashing pods. In this case HVPA controller should take VPA recommendation disregarding the vpaWeight if it is set to 0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Override vpaWeight if HPA is not maxed out and oomkill still happens
```
