### PR TITLE
Temporary/fast fix to enable scale down even if vpaWeight == 0

### DIFF
--- a/controllers/hvpa_controller_test.go
+++ b/controllers/hvpa_controller_test.go
@@ -291,7 +291,7 @@ var _ = Describe("#TestReconcile", func() {
 				Expect(scaleOutLimited).To(Equal(data.expect.scaleOutLimited))
 
 				blockedScaling := &[]*autoscalingv1alpha1.BlockedScaling{}
-				podSpec, resourceChanged, vpaStatus, err := getWeightedRequests(vpaStatus, hvpa, vpaWeight, &target.Spec.Template.Spec, scaleOutLimited, blockedScaling)
+				podSpec, resourceChanged, vpaStatus, err := getWeightedRequests(vpaStatus, hvpa, vpaWeight, *target.Spec.Replicas, &target.Spec.Template.Spec, scaleOutLimited, blockedScaling)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resourceChanged).To(Equal(data.expect.resourceChange))


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporary/fast fix to enable scale down even if vpaWeight == 0
This helps in reducing resource consumption

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
