### PR TITLE
Consider HPA to be limited if we have seen oomkill or liveness probe fails

### DIFF
--- a/controllers/hvpa_controller.go
+++ b/controllers/hvpa_controller.go
@@ -863,10 +863,11 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 	lastScaleTime := hvpa.Status.LastScaling.LastScaleTime
 	overrideScaleUpStabilization := hvpa.Status.OverrideScaleUpStabilization
 	if overrideScaleUpStabilization {
+		// Consider HPA to be limited if we have seen oomkill or liveness probe fails already.
+		hpaScaleOutLimited = true
 		log.V(2).Info("VPA", "will override last scale time in case of scale up", overrideScaleUpStabilization, "hvpa", hvpa.Namespace+"/"+hvpa.Name)
 		if vpaWeight == 0 {
 			log.V(2).Info("VPA", "will override vpaWeight from 0 to 1", "hvpa", hvpa.Namespace+"/"+hvpa.Name)
-			hpaScaleOutLimited = true
 			vpaWeight = 1
 		}
 	}


### PR DESCRIPTION
Consider HPA to be limited if we have seen oomkill or liveness probe fails already

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Consider HPA to be limited if we have seen oomkill or liveness probe fails already. This change makes HVPA controller scale the app vertically more actively, ignoring the HPA's status condition type `ScalingLimited`.
```
