### PR TITLE
Ignore minChange while overriding scale up stabilization.

### DIFF
--- a/controllers/hvpa_controller.go
+++ b/controllers/hvpa_controller.go
@@ -1017,7 +1017,7 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 						outTargetMaintenanceWindow[corev1.ResourceMemory] = rec.Target.Memory().DeepCopy()
 						blockedByMaintenanceWindow = true
 
-					} else if diffMem.Cmp(*scaleUpMinDeltaMem) < 0 {
+					} else if overrideScaleUpStabilization == false && diffMem.Cmp(*scaleUpMinDeltaMem) < 0 {
 						outTargetMinChanged[corev1.ResourceMemory] = rec.Target.Memory().DeepCopy()
 						blockedByMinChange = true
 
@@ -1103,7 +1103,7 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 						outTargetMaintenanceWindow[corev1.ResourceCPU] = rec.Target.Cpu().DeepCopy()
 						blockedByMaintenanceWindow = true
 
-					} else if diffCPU.Cmp(*scaleUpMinDeltaCPU) < 0 {
+					} else if overrideScaleUpStabilization == false && diffCPU.Cmp(*scaleUpMinDeltaCPU) < 0 {
 						outTargetMinChanged[corev1.ResourceCPU] = rec.Target.Cpu().DeepCopy()
 						blockedByMinChange = true
 

--- a/controllers/hvpa_controller_test.go
+++ b/controllers/hvpa_controller_test.go
@@ -385,8 +385,8 @@ var _ = Describe("#TestReconcile", func() {
 				},
 				action: action{
 					maintenanceWindow: &autoscalingv1alpha1.MaintenanceTimeWindow{
-						Begin: utils.NewMaintenanceTime(time.Now().UTC().Hour()+3, 0, 0).Formatted(),
-						End:   utils.NewMaintenanceTime(time.Now().UTC().Hour()+4, 0, 0).Formatted(),
+						Begin: utils.NewMaintenanceTime((time.Now().UTC().Hour()+3)%24, 0, 0).Formatted(),
+						End:   utils.NewMaintenanceTime((time.Now().UTC().Hour()+4)%24, 0, 0).Formatted(),
 					},
 					updateMode: autoscalingv1alpha1.UpdateModeMaintenanceWindow,
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Ignore `minChange` configuration while overriding scale up stabilisation. This ensures that full VPA recommendations are applied in case the target pods are `OOMKilled` or restarted due to `livenessProbe` failure, no matter what.

**Which issue(s) this PR fixes**:
Fixes #60 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Ignore `minChange` configuration while overriding scale up stabilisation. This ensures that full VPA recommendations are applied in case the target pods are OOMKilled or restarted due to livenessProbe failure, no matter what.
```
