### PR TITLE
Not to consider VPA recommendation if status conditions has type "ConfigUnsupported"

### DIFF
--- a/controllers/hvpa_controller.go
+++ b/controllers/hvpa_controller.go
@@ -850,14 +850,14 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 	}
 	for k, v := range vpaStatus.Conditions {
 		for _, condition := range unsupportedVpaConditions {
-			if v.Type == condition && v.Status == "True" {
+			if v.Type == condition && v.Status == corev1.ConditionTrue {
 				// VPA recommendations not valid
 				log.V(3).Info("VPA recommendations not valid because the following condition is true", "condition", v.Type, "hvpa", hvpa.Namespace+"/"+hvpa.Name)
 				return nil, false, nil, nil
 			}
 		}
 		if v.Type == vpa_api.RecommendationProvided {
-			if v.Status == "True" {
+			if v.Status == corev1.ConditionTrue {
 				// VPA recommendations are provided, we can do further processing
 				break
 			} else {

--- a/controllers/hvpa_controller.go
+++ b/controllers/hvpa_controller.go
@@ -844,6 +844,13 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 		return nil, false, nil, nil
 	}
 	for k, v := range vpaStatus.Conditions {
+		if v.Type == vpa_api.ConfigUnsupported || v.Type == vpa_api.ConfigDeprecated || v.Type == vpa_api.LowConfidence {
+			if v.Status == "True" {
+				// VPA recommendations not valid
+				log.V(3).Info("VPA recommendations not valid because the following condition is true", "condition", v.Type, "hvpa", hvpa.Namespace+"/"+hvpa.Name)
+				return nil, false, nil, nil
+			}
+		}
 		if v.Type == vpa_api.RecommendationProvided {
 			if v.Status == "True" {
 				// VPA recommendations are provided, we can do further processing

--- a/controllers/hvpa_controller.go
+++ b/controllers/hvpa_controller.go
@@ -843,9 +843,14 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 		log.V(2).Info("VPA: Nothing to do", "hvpa", hvpa.Namespace+"/"+hvpa.Name)
 		return nil, false, nil, nil
 	}
+	unsupportedVpaConditions := []vpa_api.VerticalPodAutoscalerConditionType{
+		vpa_api.ConfigUnsupported,
+		vpa_api.ConfigDeprecated,
+		vpa_api.LowConfidence,
+	}
 	for k, v := range vpaStatus.Conditions {
-		if v.Type == vpa_api.ConfigUnsupported || v.Type == vpa_api.ConfigDeprecated || v.Type == vpa_api.LowConfidence {
-			if v.Status == "True" {
+		for _, condition := range unsupportedVpaConditions {
+			if v.Type == condition && v.Status == "True" {
 				// VPA recommendations not valid
 				log.V(3).Info("VPA recommendations not valid because the following condition is true", "condition", v.Type, "hvpa", hvpa.Namespace+"/"+hvpa.Name)
 				return nil, false, nil, nil


### PR DESCRIPTION
Not to consider VPA recommendation if status conditions has type "ConfigUnsupported"

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Now HVPA doesn't take VPA recommendations into account if VPA condition has `ConfigUnsupported`, `ConfigDeprecated` or `LowConfidence` set to `true`
```
