### PR TITLE
consider hpa scale out limited if hpa is not deployed

### DIFF
--- a/controllers/hvpa_controller.go
+++ b/controllers/hvpa_controller.go
@@ -518,6 +518,9 @@ func (r *HvpaReconciler) scaleIfRequired(hpaStatus *autoscaling.HorizontalPodAut
 	upUpdateMode := hvpa.Spec.Hpa.ScaleUp.UpdatePolicy.UpdateMode
 
 	hpaScaleOutLimited := isHpaScaleOutLimited(hpaStatus, hvpa.Spec.Hpa.Template.Spec.MaxReplicas, upUpdateMode, hvpa.Spec.MaintenanceTimeWindow)
+	if hvpa.Spec.Hpa.Deploy == false {
+		hpaScaleOutLimited = true
+	}
 
 	blockedScaling := &[]*autoscalingv1alpha1.BlockedScaling{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
consider hpa scale out limited if hpa is not deployed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
consider hpa scale out limited if hpa is not deployed
```
