### PR TITLE
cherry-pick Cap requests to existing limits, if ControlledValues: RequestsOnly is set (#98)

### DIFF
--- a/controllers/hvpa_controller.go
+++ b/controllers/hvpa_controller.go
@@ -916,10 +916,9 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 	var maintenanceTimeWindow *utils.MaintenanceTimeWindow
 	var err error
 
-	len := len(vpaStatus.Recommendation.ContainerRecommendations)
 	outVpaStatus := &vpa_api.VerticalPodAutoscalerStatus{
 		Recommendation: &vpa_api.RecommendedPodResources{
-			ContainerRecommendations: make([]vpa_api.RecommendedContainerResources, 0, len),
+			ContainerRecommendations: make([]vpa_api.RecommendedContainerResources, 0, len(vpaStatus.Recommendation.ContainerRecommendations)),
 		},
 	}
 
@@ -986,6 +985,11 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 
 				controlledResources, controlledValues := getContainerControlledResourcesAndValues(container.Name, hvpa.Spec.Vpa.Template.Spec.ResourcePolicy)
 				newLimits := getScaledLimits(container.Resources.Limits, currReq, weightedReq, hvpa.Spec.Vpa.LimitsRequestsGapScaleParams, controlledResources, controlledValues)
+				if len(newLimits) > 0 {
+					capRequestsToLimits(weightedReq, newLimits)
+				} else {
+					capRequestsToLimits(weightedReq, container.Resources.Limits)
+				}
 
 				log.V(3).Info("VPA", "weighted target mem", weightedMem, "weighted target cpu", weightedCPU, "hvpa", hvpa.Namespace+"/"+hvpa.Name)
 				log.V(3).Info("VPA scale down", "minimum CPU delta", scaleDownMinDeltaCPU.String(), "minimum memory delta", scaleDownMinDeltaMem, "hvpa", hvpa.Namespace+"/"+hvpa.Name)
@@ -1016,12 +1020,12 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 
 						} else {
 							log.V(2).Info("VPA", "Scaling up", "memory", "Container", container.Name)
-							newPodSpec.Containers[id].Resources.Requests[corev1.ResourceMemory] = weightedMem.DeepCopy()
+							newPodSpec.Containers[id].Resources.Requests[corev1.ResourceMemory] = *weightedReq.Memory()
 							if val, ok := (newLimits)[corev1.ResourceMemory]; ok {
 								newPodSpec.Containers[id].Resources.Limits[corev1.ResourceMemory] = val
 							}
 							// Override VPA status in outVpaStatus with weighted value
-							outTarget[corev1.ResourceMemory] = weightedMem.DeepCopy()
+							outTarget[corev1.ResourceMemory] = *weightedReq.Memory()
 							resourceChange = true
 						}
 					} else if diffMem.Sign() < 0 {
@@ -1044,12 +1048,12 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 
 						} else {
 							log.V(2).Info("VPA", "Scaling down", "memory", "Container", container.Name, "hvpa", hvpa.Namespace+"/"+hvpa.Name)
-							newPodSpec.Containers[id].Resources.Requests[corev1.ResourceMemory] = weightedMem.DeepCopy()
+							newPodSpec.Containers[id].Resources.Requests[corev1.ResourceMemory] = *weightedReq.Memory()
 							if val, ok := (newLimits)[corev1.ResourceMemory]; ok {
 								newPodSpec.Containers[id].Resources.Limits[corev1.ResourceMemory] = val
 							}
 							// Override VPA status in outVpaStatus with weighted value
-							outTarget[corev1.ResourceMemory] = weightedMem.DeepCopy()
+							outTarget[corev1.ResourceMemory] = *weightedReq.Memory()
 							resourceChange = true
 						}
 					}
@@ -1080,12 +1084,12 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 
 						} else {
 							log.V(2).Info("VPA", "Scaling up", "CPU", "Container", container.Name, "hvpa", hvpa.Namespace+"/"+hvpa.Name)
-							newPodSpec.Containers[id].Resources.Requests[corev1.ResourceCPU] = weightedCPU.DeepCopy()
+							newPodSpec.Containers[id].Resources.Requests[corev1.ResourceCPU] = *weightedReq.Cpu()
 							if val, ok := (newLimits)[corev1.ResourceCPU]; ok {
 								newPodSpec.Containers[id].Resources.Limits[corev1.ResourceCPU] = val
 							}
 							// Override VPA status in outVpaStatus with weighted value
-							outTarget[corev1.ResourceCPU] = weightedCPU.DeepCopy()
+							outTarget[corev1.ResourceCPU] = *weightedReq.Cpu()
 							resourceChange = true
 						}
 					} else if diffCPU.Sign() < 0 {
@@ -1108,12 +1112,12 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 
 						} else {
 							log.V(2).Info("VPA", "Scaling down", "CPU", "Container", container.Name, "hvpa", hvpa.Namespace+"/"+hvpa.Name)
-							newPodSpec.Containers[id].Resources.Requests[corev1.ResourceCPU] = weightedCPU.DeepCopy()
+							newPodSpec.Containers[id].Resources.Requests[corev1.ResourceCPU] = *weightedReq.Cpu()
 							if val, ok := (newLimits)[corev1.ResourceCPU]; ok {
 								newPodSpec.Containers[id].Resources.Limits[corev1.ResourceCPU] = val
 							}
 							// Override VPA status in outVpaStatus with weighted value
-							outTarget[corev1.ResourceCPU] = weightedCPU.DeepCopy()
+							outTarget[corev1.ResourceCPU] = *weightedReq.Cpu()
 							resourceChange = true
 						}
 					}
@@ -1158,6 +1162,19 @@ func getWeightedRequests(vpaStatus *vpa_api.VerticalPodAutoscalerStatus, hvpa *a
 		return newPodSpec, resourceChange, outVpaStatus, nil
 	}
 	return nil, false, nil, nil
+}
+
+func capRequestsToLimits(requests corev1.ResourceList, limits corev1.ResourceList) {
+	if memLimit, ok := (limits)[corev1.ResourceMemory]; ok {
+		if memLimit.Cmp(*requests.Memory()) == -1 {
+			requests[corev1.ResourceMemory] = memLimit
+		}
+	}
+	if cpuLimit, ok := (limits)[corev1.ResourceCPU]; ok {
+		if cpuLimit.Cmp(*requests.Cpu()) == -1 {
+			requests[corev1.ResourceCPU] = cpuLimit
+		}
+	}
 }
 
 func getContainerControlledResourcesAndValues(containerName string, resourcePolicy *vpa_api.PodResourcePolicy) (*[]corev1.ResourceName, *vpa_api.ContainerControlledValues) {


### PR DESCRIPTION
**What this PR does / why we need it**:
cherry-pick of #98 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Fix an issue where the HVPA would set Requests higher than Limits if `ControlledValues: RequestsOnly` is set
```
