### PR TITLE
Build Multi-Arch Images 📦

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -8,6 +8,10 @@ hvpa-controller:
           'inject-commit-hash'
         inject_effective_version: true
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           hvpa-controller:
             registry: 'gcr-readwrite'

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /workspace
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on GOFLAGS=-mod=vendor go build -a -o manager main.go
+RUN CGO_ENABLED=0 GO111MODULE=on GOFLAGS=-mod=vendor go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR lets the CI pipeline build multi-arch images with support for `linux/amd64` and `linux/arm64`.

**Which issue(s) this PR fixes**:
Fixes parts of https://github.com/gardener/gardener/issues/6258

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Published docker images for HVPA-Controller are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```
