### PR TITLE
Run as nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN CGO_ENABLED=0 GO111MODULE=on GOFLAGS=-mod=vendor go build -a -o manager main
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static-debian11:nonroot
 WORKDIR /
+
 COPY --from=builder /go/src/github.com/gardener/hvpa-controller/manager .
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the distroless image to use a specific debian version and a non root user by default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `hvpa-controller` container image now uses a non root user by default.
```
