### PR TITLE
Update to k8s.io/autoscaling/v2beta2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ IMAGE_TAG           := $(VERSION)
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_REPOSITORY):$(IMAGE_TAG)
 
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/api/v1alpha1/hvpa_types.go
+++ b/api/v1alpha1/hvpa_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpa_api "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 )
@@ -83,7 +83,7 @@ type HpaTemplateSpec struct {
 	// more information about how each type of metric must respond.
 	// If not set, the default metric will be set to 80% average CPU utilization.
 	// +optional
-	Metrics []autoscaling.MetricSpec `json:"metrics,omitempty" protobuf:"bytes,3,rep,name=metrics"`
+	Metrics []autoscalingv2beta2.MetricSpec `json:"metrics,omitempty" protobuf:"bytes,3,rep,name=metrics"`
 }
 
 // WeightBasedScalingInterval defines the interval of replica counts in which VpaWeight is applied to VPA scaling
@@ -218,7 +218,7 @@ type HvpaSpec struct {
 	WeightBasedScalingIntervals []WeightBasedScalingInterval `json:"weightBasedScalingIntervals,omitempty"`
 
 	// TargetRef points to the controller managing the set of pods for the autoscaler to control
-	TargetRef *autoscaling.CrossVersionObjectReference `json:"targetRef"`
+	TargetRef *autoscalingv2beta2.CrossVersionObjectReference `json:"targetRef"`
 
 	// MaintenanceTimeWindow contains information about the time window for maintenance operations.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -134,7 +134,7 @@ func (in *HpaTemplateSpec) DeepCopyInto(out *HpaTemplateSpec) {
 	}
 	if in.Metrics != nil {
 		in, out := &in.Metrics, &out.Metrics
-		*out = make([]v2beta1.MetricSpec, len(*in))
+		*out = make([]v2beta2.MetricSpec, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -227,7 +227,7 @@ func (in *HvpaSpec) DeepCopyInto(out *HvpaSpec) {
 	}
 	if in.TargetRef != nil {
 		in, out := &in.TargetRef, &out.TargetRef
-		*out = new(v2beta1.CrossVersionObjectReference)
+		*out = new(v2beta2.CrossVersionObjectReference)
 		**out = **in
 	}
 	if in.MaintenanceTimeWindow != nil {

--- a/config/crd/bases/autoscaling.k8s.io_hvpas.yaml
+++ b/config/crd/bases/autoscaling.k8s.io_hvpas.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: hvpas.autoscaling.k8s.io
 spec:
@@ -22,10 +21,14 @@ spec:
         description: Hvpa is the Schema for the hvpas API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -42,13 +45,16 @@ spec:
                     description: ScaleDown defines the parameters for scale down
                     properties:
                       minChange:
-                        description: MinChange is the minimum change in the resource on which HVPA acts HVPA uses minimum of the Value and Percentage value
+                        description: MinChange is the minimum change in the resource
+                          on which HVPA acts HVPA uses minimum of the Value and Percentage
+                          value
                         properties:
                           cpu:
                             description: Scale parameters for CPU
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -59,7 +65,8 @@ spec:
                             description: Scale parameters for memory
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -70,7 +77,8 @@ spec:
                             description: Scale patameters for replicas
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -79,13 +87,18 @@ spec:
                             type: object
                         type: object
                       stabilizationDuration:
-                        description: StabilizationDuration defines the minimum delay in minutes between 2 consecutive scale operations Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        description: StabilizationDuration defines the minimum delay
+                          in minutes between 2 consecutive scale operations Valid
+                          time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
                         type: string
                       updatePolicy:
-                        description: Describes the rules on when changes are applied. If not specified, all fields in the `UpdatePolicy` are set to their default values.
+                        description: Describes the rules on when changes are applied.
+                          If not specified, all fields in the `UpdatePolicy` are set
+                          to their default values.
                         properties:
                           updateMode:
-                            description: Controls when autoscaler applies changes to the resources. The default is 'Auto'.
+                            description: Controls when autoscaler applies changes
+                              to the resources. The default is 'Auto'.
                             type: string
                         type: object
                     type: object
@@ -93,13 +106,16 @@ spec:
                     description: ScaleUp defines the parameters for scale up
                     properties:
                       minChange:
-                        description: MinChange is the minimum change in the resource on which HVPA acts HVPA uses minimum of the Value and Percentage value
+                        description: MinChange is the minimum change in the resource
+                          on which HVPA acts HVPA uses minimum of the Value and Percentage
+                          value
                         properties:
                           cpu:
                             description: Scale parameters for CPU
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -110,7 +126,8 @@ spec:
                             description: Scale parameters for memory
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -121,7 +138,8 @@ spec:
                             description: Scale patameters for replicas
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -130,32 +148,49 @@ spec:
                             type: object
                         type: object
                       stabilizationDuration:
-                        description: StabilizationDuration defines the minimum delay in minutes between 2 consecutive scale operations Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        description: StabilizationDuration defines the minimum delay
+                          in minutes between 2 consecutive scale operations Valid
+                          time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
                         type: string
                       updatePolicy:
-                        description: Describes the rules on when changes are applied. If not specified, all fields in the `UpdatePolicy` are set to their default values.
+                        description: Describes the rules on when changes are applied.
+                          If not specified, all fields in the `UpdatePolicy` are set
+                          to their default values.
                         properties:
                           updateMode:
-                            description: Controls when autoscaler applies changes to the resources. The default is 'Auto'.
+                            description: Controls when autoscaler applies changes
+                              to the resources. The default is 'Auto'.
                             type: string
                         type: object
                     type: object
                   selector:
-                    description: 'Selector is a label query that should match HPA. Must match in order to be controlled. If empty, defaulted to labels on HPA template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                    description: 'Selector is a label query that should match HPA.
+                      Must match in order to be controlled. If empty, defaulted to
+                      labels on HPA template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -167,11 +202,16 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
                         type: object
                     type: object
                   template:
-                    description: Template is the object that describes the HPA that will be created.
+                    description: Template is the object that describes the HPA that
+                      will be created.
                     properties:
                       metadata:
                         description: Metadata of the pods created from this template.
@@ -181,214 +221,479 @@ spec:
                         description: Spec defines the behavior of a HPA.
                         properties:
                           maxReplicas:
-                            description: maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
+                            description: maxReplicas is the upper limit for the number
+                              of replicas to which the autoscaler can scale up. It
+                              cannot be less that minReplicas.
                             format: int32
                             type: integer
                           metrics:
-                            description: metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
+                            description: metrics contains the specifications for which
+                              to use to calculate the desired replica count (the maximum
+                              replica count across all metrics will be used).  The
+                              desired replica count is calculated multiplying the
+                              ratio between the target value and the current value
+                              by the current number of pods.  Ergo, metrics used must
+                              decrease as the pod count is increased, and vice-versa.  See
+                              the individual metric source types for more information
+                              about how each type of metric must respond. If not set,
+                              the default metric will be set to 80% average CPU utilization.
                             items:
-                              description: MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).
+                              description: MetricSpec specifies how to scale based
+                                on a single metric (only `type` and one other matching
+                                field should be set at once).
                               properties:
                                 external:
-                                  description: external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+                                  description: external refers to a global metric
+                                    that is not associated with any Kubernetes object.
+                                    It allows autoscaling based on information coming
+                                    from components running outside of cluster (for
+                                    example length of queue in cloud messaging service,
+                                    or QPS from loadbalancer running outside of cluster).
                                   properties:
-                                    metricName:
-                                      description: metricName is the name of the metric in question.
-                                      type: string
-                                    metricSelector:
-                                      description: metricSelector is used to identify a specific time series within a given metric.
+                                    metric:
+                                      description: metric identifies the target metric
+                                        by name and selector
                                       properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                          items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key that the selector applies to.
+                                        name:
+                                          description: name is the name of the given
+                                            metric
+                                          type: string
+                                        selector:
+                                          description: selector is the string-encoded
+                                            form of a standard kubernetes label selector
+                                            for the given metric When set, it is passed
+                                            as an additional parameter to the metrics
+                                            server for more specific metrics scoping.
+                                            When unset, just the metricName will be
+                                            used to gather metrics.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
                                                 type: string
-                                              operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
                                           type: object
-                                      type: object
-                                    targetAverageValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: targetAverageValue is the target per-pod value of global metric (as a quantity). Mutually exclusive with TargetValue.
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    targetValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: targetValue is the target value of the metric (as a quantity). Mutually exclusive with TargetAverageValue.
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - metricName
-                                  type: object
-                                object:
-                                  description: object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
-                                  properties:
-                                    averageValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    metricName:
-                                      description: metricName is the name of the metric in question.
-                                      type: string
-                                    selector:
-                                      description: selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
-                                      properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                          items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key that the selector applies to.
-                                                type: string
-                                              operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                          type: object
+                                      required:
+                                      - name
                                       type: object
                                     target:
-                                      description: target is the described Kubernetes object.
+                                      description: target specifies the target value
+                                        for the given metric
+                                      properties:
+                                        averageUtilization:
+                                          description: averageUtilization is the target
+                                            value of the average of the resource metric
+                                            across all relevant pods, represented
+                                            as a percentage of the requested value
+                                            of the resource for the pods. Currently
+                                            only valid for Resource metric source
+                                            type
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: averageValue is the target
+                                            value of the average of the metric across
+                                            all relevant pods (as a quantity)
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: type represents whether the
+                                            metric type is Utilization, Value, or
+                                            AverageValue
+                                          type: string
+                                        value:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: value is the target value of
+                                            the metric (as a quantity).
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                object:
+                                  description: object refers to a metric describing
+                                    a single kubernetes object (for example, hits-per-second
+                                    on an Ingress object).
+                                  properties:
+                                    describedObject:
+                                      description: CrossVersionObjectReference contains
+                                        enough information to let you identify the
+                                        referred resource.
                                       properties:
                                         apiVersion:
                                           description: API version of the referent
                                           type: string
                                         kind:
-                                          description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                          description: 'Kind of the referent; More
+                                            info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                           type: string
                                         name:
-                                          description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                          description: 'Name of the referent; More
+                                            info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                           type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
-                                    targetValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: targetValue is the target value of the metric (as a quantity).
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                    metric:
+                                      description: metric identifies the target metric
+                                        by name and selector
+                                      properties:
+                                        name:
+                                          description: name is the name of the given
+                                            metric
+                                          type: string
+                                        selector:
+                                          description: selector is the string-encoded
+                                            form of a standard kubernetes label selector
+                                            for the given metric When set, it is passed
+                                            as an additional parameter to the metrics
+                                            server for more specific metrics scoping.
+                                            When unset, just the metricName will be
+                                            used to gather metrics.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      description: target specifies the target value
+                                        for the given metric
+                                      properties:
+                                        averageUtilization:
+                                          description: averageUtilization is the target
+                                            value of the average of the resource metric
+                                            across all relevant pods, represented
+                                            as a percentage of the requested value
+                                            of the resource for the pods. Currently
+                                            only valid for Resource metric source
+                                            type
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: averageValue is the target
+                                            value of the average of the metric across
+                                            all relevant pods (as a quantity)
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: type represents whether the
+                                            metric type is Utilization, Value, or
+                                            AverageValue
+                                          type: string
+                                        value:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: value is the target value of
+                                            the metric (as a quantity).
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - type
+                                      type: object
                                   required:
-                                  - metricName
+                                  - describedObject
+                                  - metric
                                   - target
-                                  - targetValue
                                   type: object
                                 pods:
-                                  description: pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+                                  description: pods refers to a metric describing
+                                    each pod in the current scale target (for example,
+                                    transactions-processed-per-second).  The values
+                                    will be averaged together before being compared
+                                    to the target value.
                                   properties:
-                                    metricName:
-                                      description: metricName is the name of the metric in question
-                                      type: string
-                                    selector:
-                                      description: selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
+                                    metric:
+                                      description: metric identifies the target metric
+                                        by name and selector
                                       properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                          items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key that the selector applies to.
+                                        name:
+                                          description: name is the name of the given
+                                            metric
+                                          type: string
+                                        selector:
+                                          description: selector is the string-encoded
+                                            form of a standard kubernetes label selector
+                                            for the given metric When set, it is passed
+                                            as an additional parameter to the metrics
+                                            server for more specific metrics scoping.
+                                            When unset, just the metricName will be
+                                            used to gather metrics.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
                                                 type: string
-                                              operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
                                           type: object
+                                      required:
+                                      - name
                                       type: object
-                                    targetAverageValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: targetAverageValue is the target value of the average of the metric across all relevant pods (as a quantity)
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                    target:
+                                      description: target specifies the target value
+                                        for the given metric
+                                      properties:
+                                        averageUtilization:
+                                          description: averageUtilization is the target
+                                            value of the average of the resource metric
+                                            across all relevant pods, represented
+                                            as a percentage of the requested value
+                                            of the resource for the pods. Currently
+                                            only valid for Resource metric source
+                                            type
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: averageValue is the target
+                                            value of the average of the metric across
+                                            all relevant pods (as a quantity)
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: type represents whether the
+                                            metric type is Utilization, Value, or
+                                            AverageValue
+                                          type: string
+                                        value:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: value is the target value of
+                                            the metric (as a quantity).
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - type
+                                      type: object
                                   required:
-                                  - metricName
-                                  - targetAverageValue
+                                  - metric
+                                  - target
                                   type: object
                                 resource:
-                                  description: resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+                                  description: resource refers to a resource metric
+                                    (such as those specified in requests and limits)
+                                    known to Kubernetes describing each pod in the
+                                    current scale target (e.g. CPU or memory). Such
+                                    metrics are built in to Kubernetes, and have special
+                                    scaling options on top of those available to normal
+                                    per-pod metrics using the "pods" source.
                                   properties:
                                     name:
-                                      description: name is the name of the resource in question.
+                                      description: name is the name of the resource
+                                        in question.
                                       type: string
-                                    targetAverageUtilization:
-                                      description: targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
-                                      format: int32
-                                      type: integer
-                                    targetAverageValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type.
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                    target:
+                                      description: target specifies the target value
+                                        for the given metric
+                                      properties:
+                                        averageUtilization:
+                                          description: averageUtilization is the target
+                                            value of the average of the resource metric
+                                            across all relevant pods, represented
+                                            as a percentage of the requested value
+                                            of the resource for the pods. Currently
+                                            only valid for Resource metric source
+                                            type
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: averageValue is the target
+                                            value of the average of the metric across
+                                            all relevant pods (as a quantity)
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: type represents whether the
+                                            metric type is Utilization, Value, or
+                                            AverageValue
+                                          type: string
+                                        value:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: value is the target value of
+                                            the metric (as a quantity).
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - type
+                                      type: object
                                   required:
                                   - name
+                                  - target
                                   type: object
                                 type:
-                                  description: type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+                                  description: type is the type of metric source.  It
+                                    should be one of "Object", "Pods" or "Resource",
+                                    each mapping to a matching field in the object.
                                   type: string
                               required:
                               - type
                               type: object
                             type: array
                           minReplicas:
-                            description: minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down. It defaults to 1 pod.
+                            description: minReplicas is the lower limit for the number
+                              of replicas to which the autoscaler can scale down.
+                              It defaults to 1 pod.
                             format: int32
                             type: integer
                         required:
@@ -397,13 +702,16 @@ spec:
                     type: object
                 type: object
               maintenanceTimeWindow:
-                description: MaintenanceTimeWindow contains information about the time window for maintenance operations.
+                description: MaintenanceTimeWindow contains information about the
+                  time window for maintenance operations.
                 properties:
                   begin:
-                    description: Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+                    description: Begin is the beginning of the time window in the
+                      format HHMMSS+ZONE, e.g. "220000+0100".
                     type: string
                   end:
-                    description: End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+                    description: End is the end of the time window in the format HHMMSS+ZONE,
+                      e.g. "220000+0100".
                     type: string
                 required:
                 - begin
@@ -414,7 +722,8 @@ spec:
                 format: int32
                 type: integer
               targetRef:
-                description: TargetRef points to the controller managing the set of pods for the autoscaler to control
+                description: TargetRef points to the controller managing the set of
+                  pods for the autoscaler to control
                 properties:
                   apiVersion:
                     description: API version of the referent
@@ -436,13 +745,15 @@ spec:
                     description: Deploy defines whether the VPA is deployed or not
                     type: boolean
                   limitsRequestsGapScaleParams:
-                    description: LimitsRequestsGapScaleParams is the scaling thresholds for limits
+                    description: LimitsRequestsGapScaleParams is the scaling thresholds
+                      for limits
                     properties:
                       cpu:
                         description: Scale parameters for CPU
                         properties:
                           percentage:
-                            description: Percentage is the percentage of currently allocated value to be used for scaling
+                            description: Percentage is the percentage of currently
+                              allocated value to be used for scaling
                             format: int32
                             type: integer
                           value:
@@ -453,7 +764,8 @@ spec:
                         description: Scale parameters for memory
                         properties:
                           percentage:
-                            description: Percentage is the percentage of currently allocated value to be used for scaling
+                            description: Percentage is the percentage of currently
+                              allocated value to be used for scaling
                             format: int32
                             type: integer
                           value:
@@ -464,7 +776,8 @@ spec:
                         description: Scale patameters for replicas
                         properties:
                           percentage:
-                            description: Percentage is the percentage of currently allocated value to be used for scaling
+                            description: Percentage is the percentage of currently
+                              allocated value to be used for scaling
                             format: int32
                             type: integer
                           value:
@@ -476,13 +789,16 @@ spec:
                     description: ScaleDown defines the parameters for scale down
                     properties:
                       minChange:
-                        description: MinChange is the minimum change in the resource on which HVPA acts HVPA uses minimum of the Value and Percentage value
+                        description: MinChange is the minimum change in the resource
+                          on which HVPA acts HVPA uses minimum of the Value and Percentage
+                          value
                         properties:
                           cpu:
                             description: Scale parameters for CPU
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -493,7 +809,8 @@ spec:
                             description: Scale parameters for memory
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -504,7 +821,8 @@ spec:
                             description: Scale patameters for replicas
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -513,13 +831,18 @@ spec:
                             type: object
                         type: object
                       stabilizationDuration:
-                        description: StabilizationDuration defines the minimum delay in minutes between 2 consecutive scale operations Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        description: StabilizationDuration defines the minimum delay
+                          in minutes between 2 consecutive scale operations Valid
+                          time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
                         type: string
                       updatePolicy:
-                        description: Describes the rules on when changes are applied. If not specified, all fields in the `UpdatePolicy` are set to their default values.
+                        description: Describes the rules on when changes are applied.
+                          If not specified, all fields in the `UpdatePolicy` are set
+                          to their default values.
                         properties:
                           updateMode:
-                            description: Controls when autoscaler applies changes to the resources. The default is 'Auto'.
+                            description: Controls when autoscaler applies changes
+                              to the resources. The default is 'Auto'.
                             type: string
                         type: object
                     type: object
@@ -527,13 +850,16 @@ spec:
                     description: ScaleUp defines the parameters for scale up
                     properties:
                       minChange:
-                        description: MinChange is the minimum change in the resource on which HVPA acts HVPA uses minimum of the Value and Percentage value
+                        description: MinChange is the minimum change in the resource
+                          on which HVPA acts HVPA uses minimum of the Value and Percentage
+                          value
                         properties:
                           cpu:
                             description: Scale parameters for CPU
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -544,7 +870,8 @@ spec:
                             description: Scale parameters for memory
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -555,7 +882,8 @@ spec:
                             description: Scale patameters for replicas
                             properties:
                               percentage:
-                                description: Percentage is the percentage of currently allocated value to be used for scaling
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
                                 format: int32
                                 type: integer
                               value:
@@ -564,32 +892,49 @@ spec:
                             type: object
                         type: object
                       stabilizationDuration:
-                        description: StabilizationDuration defines the minimum delay in minutes between 2 consecutive scale operations Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        description: StabilizationDuration defines the minimum delay
+                          in minutes between 2 consecutive scale operations Valid
+                          time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
                         type: string
                       updatePolicy:
-                        description: Describes the rules on when changes are applied. If not specified, all fields in the `UpdatePolicy` are set to their default values.
+                        description: Describes the rules on when changes are applied.
+                          If not specified, all fields in the `UpdatePolicy` are set
+                          to their default values.
                         properties:
                           updateMode:
-                            description: Controls when autoscaler applies changes to the resources. The default is 'Auto'.
+                            description: Controls when autoscaler applies changes
+                              to the resources. The default is 'Auto'.
                             type: string
                         type: object
                     type: object
                   selector:
-                    description: 'Selector is a label query that should match VPA. Must match in order to be controlled. If empty, defaulted to labels on VPA template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                    description: 'Selector is a label query that should match VPA.
+                      Must match in order to be controlled. If empty, defaulted to
+                      labels on VPA template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -601,11 +946,16 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
                         type: object
                     type: object
                   template:
-                    description: Template is the object that describes the VPA that will be created.
+                    description: Template is the object that describes the VPA that
+                      will be created.
                     properties:
                       metadata:
                         description: Metadata of the pods created from this template.
@@ -615,24 +965,37 @@ spec:
                         description: Spec defines the behavior of a VPA.
                         properties:
                           resourcePolicy:
-                            description: Controls how the autoscaler computes recommended resources. The resource policy may be used to set constraints on the recommendations for individual containers. If not specified, the autoscaler computes recommended resources for all containers in the pod, without additional constraints.
+                            description: Controls how the autoscaler computes recommended
+                              resources. The resource policy may be used to set constraints
+                              on the recommendations for individual containers. If
+                              not specified, the autoscaler computes recommended resources
+                              for all containers in the pod, without additional constraints.
                             properties:
                               containerPolicies:
                                 description: Per-container resource policies.
                                 items:
-                                  description: ContainerResourcePolicy controls how autoscaler computes the recommended resources for a specific container.
+                                  description: ContainerResourcePolicy controls how
+                                    autoscaler computes the recommended resources
+                                    for a specific container.
                                   properties:
                                     containerName:
-                                      description: Name of the container or DefaultContainerResourcePolicy, in which case the policy is used by the containers that don't have their own policy specified.
+                                      description: Name of the container or DefaultContainerResourcePolicy,
+                                        in which case the policy is used by the containers
+                                        that don't have their own policy specified.
                                       type: string
                                     controlledResources:
-                                      description: Specifies the type of recommendations that will be computed (and possibly applied) by VPA. If not specified, the default of [ResourceCPU, ResourceMemory] will be used.
+                                      description: Specifies the type of recommendations
+                                        that will be computed (and possibly applied)
+                                        by VPA. If not specified, the default of [ResourceCPU,
+                                        ResourceMemory] will be used.
                                       items:
-                                        description: ResourceName is the name identifying various resources in a ResourceList.
+                                        description: ResourceName is the name identifying
+                                          various resources in a ResourceList.
                                         type: string
                                       type: array
                                     controlledValues:
-                                      description: Specifies which resource values should be controlled. The default is "RequestsAndLimits".
+                                      description: Specifies which resource values
+                                        should be controlled. The default is "RequestsAndLimits".
                                       type: string
                                     maxAllowed:
                                       additionalProperties:
@@ -641,7 +1004,9 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: Specifies the maximum amount of resources that will be recommended for the container. The default is no maximum.
+                                      description: Specifies the maximum amount of
+                                        resources that will be recommended for the
+                                        container. The default is no maximum.
                                       type: object
                                     minAllowed:
                                       additionalProperties:
@@ -650,10 +1015,13 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: Specifies the minimal amount of resources that will be recommended for the container. The default is no minimum.
+                                      description: Specifies the minimal amount of
+                                        resources that will be recommended for the
+                                        container. The default is no minimum.
                                       type: object
                                     mode:
-                                      description: Whether autoscaler is enabled for the container. The default is "Auto".
+                                      description: Whether autoscaler is enabled for
+                                        the container. The default is "Auto".
                                       type: string
                                   type: object
                                 type: array
@@ -662,20 +1030,30 @@ spec:
                     type: object
                 type: object
               weightBasedScalingIntervals:
-                description: WeightBasedScalingIntervals defines the intervals of replica counts, and the weights for scaling a deployment vertically If there are overlapping intervals, then the vpaWeight will be taken from the first matching interval
+                description: WeightBasedScalingIntervals defines the intervals of
+                  replica counts, and the weights for scaling a deployment vertically
+                  If there are overlapping intervals, then the vpaWeight will be taken
+                  from the first matching interval
                 items:
-                  description: WeightBasedScalingInterval defines the interval of replica counts in which VpaWeight is applied to VPA scaling
+                  description: WeightBasedScalingInterval defines the interval of
+                    replica counts in which VpaWeight is applied to VPA scaling
                   properties:
                     lastReplicaCount:
-                      description: LastReplicaCount is the number of replicas till which VpaWeight is applied to VPA scaling If this field is not provided, it will default to maxReplicas of HPA
+                      description: LastReplicaCount is the number of replicas till
+                        which VpaWeight is applied to VPA scaling If this field is
+                        not provided, it will default to maxReplicas of HPA
                       format: int32
                       type: integer
                     startReplicaCount:
-                      description: StartReplicaCount is the number of replicas from which VpaWeight is applied to VPA scaling If this field is not provided, it will default to minReplicas of HPA
+                      description: StartReplicaCount is the number of replicas from
+                        which VpaWeight is applied to VPA scaling If this field is
+                        not provided, it will default to minReplicas of HPA
                       format: int32
                       type: integer
                     vpaWeight:
-                      description: VpaWeight defines the weight (in percentage) to be given to VPA's recommendationd for the interval of number of replicas provided
+                      description: VpaWeight defines the weight (in percentage) to
+                        be given to VPA's recommendationd for the interval of number
+                        of replicas provided
                       format: int32
                       maximum: 100
                       minimum: 0
@@ -692,14 +1070,16 @@ spec:
                 description: Current HPA UpdatePolicy set in the spec
                 properties:
                   updateMode:
-                    description: Controls when autoscaler applies changes to the resources. The default is 'Auto'.
+                    description: Controls when autoscaler applies changes to the resources.
+                      The default is 'Auto'.
                     type: string
                 type: object
               hpaScaleUpUpdatePolicy:
                 description: Current HPA UpdatePolicy set in the spec
                 properties:
                   updateMode:
-                    description: Controls when autoscaler applies changes to the resources. The default is 'Auto'.
+                    description: Controls when autoscaler applies changes to the resources.
+                      The default is 'Auto'.
                     type: string
                 type: object
               hpaWeight:
@@ -729,25 +1109,35 @@ spec:
                           format: date-time
                           type: string
                         vpaStatus:
-                          description: VerticalPodAutoscalerStatus describes the runtime state of the autoscaler.
+                          description: VerticalPodAutoscalerStatus describes the runtime
+                            state of the autoscaler.
                           properties:
                             conditions:
-                              description: Conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.
+                              description: Conditions is the set of conditions required
+                                for this autoscaler to scale its target, and indicates
+                                whether or not those conditions are met.
                               items:
-                                description: VerticalPodAutoscalerCondition describes the state of a VerticalPodAutoscaler at a certain point.
+                                description: VerticalPodAutoscalerCondition describes
+                                  the state of a VerticalPodAutoscaler at a certain
+                                  point.
                                 properties:
                                   lastTransitionTime:
-                                    description: lastTransitionTime is the last time the condition transitioned from one status to another
+                                    description: lastTransitionTime is the last time
+                                      the condition transitioned from one status to
+                                      another
                                     format: date-time
                                     type: string
                                   message:
-                                    description: message is a human-readable explanation containing details about the transition
+                                    description: message is a human-readable explanation
+                                      containing details about the transition
                                     type: string
                                   reason:
-                                    description: reason is the reason for the condition's last transition.
+                                    description: reason is the reason for the condition's
+                                      last transition.
                                     type: string
                                   status:
-                                    description: status is the status of the condition (True, False, Unknown)
+                                    description: status is the status of the condition
+                                      (True, False, Unknown)
                                     type: string
                                   type:
                                     description: type describes the current condition
@@ -758,12 +1148,20 @@ spec:
                                 type: object
                               type: array
                             recommendation:
-                              description: The most recently computed amount of resources recommended by the autoscaler for the controlled pods.
+                              description: The most recently computed amount of resources
+                                recommended by the autoscaler for the controlled pods.
                               properties:
                                 containerRecommendations:
-                                  description: Resources recommended by the autoscaler for each container.
+                                  description: Resources recommended by the autoscaler
+                                    for each container.
                                   items:
-                                    description: RecommendedContainerResources is the recommendation of resources computed by autoscaler for a specific container. Respects the container resource policy if present in the spec. In particular the recommendation is not produced for containers with `ContainerScalingMode` set to 'Off'.
+                                    description: RecommendedContainerResources is
+                                      the recommendation of resources computed by
+                                      autoscaler for a specific container. Respects
+                                      the container resource policy if present in
+                                      the spec. In particular the recommendation is
+                                      not produced for containers with `ContainerScalingMode`
+                                      set to 'Off'.
                                     properties:
                                       containerName:
                                         description: Name of the container.
@@ -775,7 +1173,13 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: Minimum recommended amount of resources. Observes ContainerResourcePolicy. This amount is not guaranteed to be sufficient for the application to operate in a stable way, however running with less resources is likely to have significant impact on performance/availability.
+                                        description: Minimum recommended amount of
+                                          resources. Observes ContainerResourcePolicy.
+                                          This amount is not guaranteed to be sufficient
+                                          for the application to operate in a stable
+                                          way, however running with less resources
+                                          is likely to have significant impact on
+                                          performance/availability.
                                         type: object
                                       target:
                                         additionalProperties:
@@ -784,7 +1188,8 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                                        description: Recommended amount of resources.
+                                          Observes ContainerResourcePolicy.
                                         type: object
                                       uncappedTarget:
                                         additionalProperties:
@@ -793,7 +1198,16 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: The most recent recommended resources target computed by the autoscaler for the controlled pods, based only on actual resource usage, not taking into account the ContainerResourcePolicy. May differ from the Recommendation if the actual resource usage causes the target to violate the ContainerResourcePolicy (lower than MinAllowed or higher that MaxAllowed). Used only as status indication, will not affect actual resource assignment.
+                                        description: The most recent recommended resources
+                                          target computed by the autoscaler for the
+                                          controlled pods, based only on actual resource
+                                          usage, not taking into account the ContainerResourcePolicy.
+                                          May differ from the Recommendation if the
+                                          actual resource usage causes the target
+                                          to violate the ContainerResourcePolicy (lower
+                                          than MinAllowed or higher that MaxAllowed).
+                                          Used only as status indication, will not
+                                          affect actual resource assignment.
                                         type: object
                                       upperBound:
                                         additionalProperties:
@@ -802,7 +1216,12 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: Maximum recommended amount of resources. Observes ContainerResourcePolicy. Any resources allocated beyond this value are likely wasted. This value may be larger than the maximum amount of application is actually capable of consuming.
+                                        description: Maximum recommended amount of
+                                          resources. Observes ContainerResourcePolicy.
+                                          Any resources allocated beyond this value
+                                          are likely wasted. This value may be larger
+                                          than the maximum amount of application is
+                                          actually capable of consuming.
                                         type: object
                                     required:
                                     - target
@@ -820,7 +1239,8 @@ spec:
                     description: Description of the error
                     type: string
                   lastOperation:
-                    description: LastOperation is the type of operation for which error occurred
+                    description: LastOperation is the type of operation for which
+                      error occurred
                     type: string
                   lastUpdateTime:
                     description: Time at which the error occurred
@@ -844,25 +1264,33 @@ spec:
                     format: date-time
                     type: string
                   vpaStatus:
-                    description: VerticalPodAutoscalerStatus describes the runtime state of the autoscaler.
+                    description: VerticalPodAutoscalerStatus describes the runtime
+                      state of the autoscaler.
                     properties:
                       conditions:
-                        description: Conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.
+                        description: Conditions is the set of conditions required
+                          for this autoscaler to scale its target, and indicates whether
+                          or not those conditions are met.
                         items:
-                          description: VerticalPodAutoscalerCondition describes the state of a VerticalPodAutoscaler at a certain point.
+                          description: VerticalPodAutoscalerCondition describes the
+                            state of a VerticalPodAutoscaler at a certain point.
                           properties:
                             lastTransitionTime:
-                              description: lastTransitionTime is the last time the condition transitioned from one status to another
+                              description: lastTransitionTime is the last time the
+                                condition transitioned from one status to another
                               format: date-time
                               type: string
                             message:
-                              description: message is a human-readable explanation containing details about the transition
+                              description: message is a human-readable explanation
+                                containing details about the transition
                               type: string
                             reason:
-                              description: reason is the reason for the condition's last transition.
+                              description: reason is the reason for the condition's
+                                last transition.
                               type: string
                             status:
-                              description: status is the status of the condition (True, False, Unknown)
+                              description: status is the status of the condition (True,
+                                False, Unknown)
                               type: string
                             type:
                               description: type describes the current condition
@@ -873,12 +1301,19 @@ spec:
                           type: object
                         type: array
                       recommendation:
-                        description: The most recently computed amount of resources recommended by the autoscaler for the controlled pods.
+                        description: The most recently computed amount of resources
+                          recommended by the autoscaler for the controlled pods.
                         properties:
                           containerRecommendations:
-                            description: Resources recommended by the autoscaler for each container.
+                            description: Resources recommended by the autoscaler for
+                              each container.
                             items:
-                              description: RecommendedContainerResources is the recommendation of resources computed by autoscaler for a specific container. Respects the container resource policy if present in the spec. In particular the recommendation is not produced for containers with `ContainerScalingMode` set to 'Off'.
+                              description: RecommendedContainerResources is the recommendation
+                                of resources computed by autoscaler for a specific
+                                container. Respects the container resource policy
+                                if present in the spec. In particular the recommendation
+                                is not produced for containers with `ContainerScalingMode`
+                                set to 'Off'.
                               properties:
                                 containerName:
                                   description: Name of the container.
@@ -890,7 +1325,12 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Minimum recommended amount of resources. Observes ContainerResourcePolicy. This amount is not guaranteed to be sufficient for the application to operate in a stable way, however running with less resources is likely to have significant impact on performance/availability.
+                                  description: Minimum recommended amount of resources.
+                                    Observes ContainerResourcePolicy. This amount
+                                    is not guaranteed to be sufficient for the application
+                                    to operate in a stable way, however running with
+                                    less resources is likely to have significant impact
+                                    on performance/availability.
                                   type: object
                                 target:
                                   additionalProperties:
@@ -899,7 +1339,8 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                                  description: Recommended amount of resources. Observes
+                                    ContainerResourcePolicy.
                                   type: object
                                 uncappedTarget:
                                   additionalProperties:
@@ -908,7 +1349,15 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: The most recent recommended resources target computed by the autoscaler for the controlled pods, based only on actual resource usage, not taking into account the ContainerResourcePolicy. May differ from the Recommendation if the actual resource usage causes the target to violate the ContainerResourcePolicy (lower than MinAllowed or higher that MaxAllowed). Used only as status indication, will not affect actual resource assignment.
+                                  description: The most recent recommended resources
+                                    target computed by the autoscaler for the controlled
+                                    pods, based only on actual resource usage, not
+                                    taking into account the ContainerResourcePolicy.
+                                    May differ from the Recommendation if the actual
+                                    resource usage causes the target to violate the
+                                    ContainerResourcePolicy (lower than MinAllowed
+                                    or higher that MaxAllowed). Used only as status
+                                    indication, will not affect actual resource assignment.
                                   type: object
                                 upperBound:
                                   additionalProperties:
@@ -917,7 +1366,11 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Maximum recommended amount of resources. Observes ContainerResourcePolicy. Any resources allocated beyond this value are likely wasted. This value may be larger than the maximum amount of application is actually capable of consuming.
+                                  description: Maximum recommended amount of resources.
+                                    Observes ContainerResourcePolicy. Any resources
+                                    allocated beyond this value are likely wasted.
+                                    This value may be larger than the maximum amount
+                                    of application is actually capable of consuming.
                                   type: object
                               required:
                               - target
@@ -934,20 +1387,23 @@ spec:
                 format: int32
                 type: integer
               targetSelector:
-                description: TargetSelector is the string form of the label selector of HPA. This is required for HPA to work with scale subresource.
+                description: TargetSelector is the string form of the label selector
+                  of HPA. This is required for HPA to work with scale subresource.
                 type: string
               vpaScaleDownUpdatePolicy:
                 description: Current VPA UpdatePolicy set in the spec
                 properties:
                   updateMode:
-                    description: Controls when autoscaler applies changes to the resources. The default is 'Auto'.
+                    description: Controls when autoscaler applies changes to the resources.
+                      The default is 'Auto'.
                     type: string
                 type: object
               vpaScaleUpUpdatePolicy:
                 description: Current VPA UpdatePolicy set in the spec
                 properties:
                   updateMode:
-                    description: Controls when autoscaler applies changes to the resources. The default is 'Auto'.
+                    description: Controls when autoscaler applies changes to the resources.
+                      The default is 'Auto'.
                     type: string
                 type: object
               vpaWeight:
@@ -963,9 +1419,3 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/output/crds.yaml
+++ b/config/crd/output/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, temporarily squatting
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   name: hvpas.autoscaling.k8s.io
 spec:
   group: autoscaling.k8s.io
@@ -249,161 +249,129 @@ spec:
                                     example length of queue in cloud messaging service,
                                     or QPS from loadbalancer running outside of cluster).
                                   properties:
-                                    metricName:
-                                      description: metricName is the name of the metric
-                                        in question.
-                                      type: string
-                                    metricSelector:
-                                      description: metricSelector is used to identify
-                                        a specific time series within a given metric.
+                                    metric:
+                                      description: metric identifies the target metric
+                                        by name and selector
                                       properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
-                                          items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key
-                                                  that the selector applies to.
+                                        name:
+                                          description: name is the name of the given
+                                            metric
+                                          type: string
+                                        selector:
+                                          description: selector is the string-encoded
+                                            form of a standard kubernetes label selector
+                                            for the given metric When set, it is passed
+                                            as an additional parameter to the metrics
+                                            server for more specific metrics scoping.
+                                            When unset, just the metricName will be
+                                            used to gather metrics.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
                                                 type: string
-                                              operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
                                           type: object
+                                      required:
+                                      - name
                                       type: object
-                                    targetAverageValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: targetAverageValue is the target
-                                        per-pod value of global metric (as a quantity).
-                                        Mutually exclusive with TargetValue.
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    targetValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: targetValue is the target value
-                                        of the metric (as a quantity). Mutually exclusive
-                                        with TargetAverageValue.
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                    target:
+                                      description: target specifies the target value
+                                        for the given metric
+                                      properties:
+                                        averageUtilization:
+                                          description: averageUtilization is the target
+                                            value of the average of the resource metric
+                                            across all relevant pods, represented
+                                            as a percentage of the requested value
+                                            of the resource for the pods. Currently
+                                            only valid for Resource metric source
+                                            type
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: averageValue is the target
+                                            value of the average of the metric across
+                                            all relevant pods (as a quantity)
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: type represents whether the
+                                            metric type is Utilization, Value, or
+                                            AverageValue
+                                          type: string
+                                        value:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: value is the target value of
+                                            the metric (as a quantity).
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - type
+                                      type: object
                                   required:
-                                  - metricName
+                                  - metric
+                                  - target
                                   type: object
                                 object:
                                   description: object refers to a metric describing
                                     a single kubernetes object (for example, hits-per-second
                                     on an Ingress object).
                                   properties:
-                                    averageValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: averageValue is the target value
-                                        of the average of the metric across all relevant
-                                        pods (as a quantity)
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    metricName:
-                                      description: metricName is the name of the metric
-                                        in question.
-                                      type: string
-                                    selector:
-                                      description: selector is the string-encoded
-                                        form of a standard kubernetes label selector
-                                        for the given metric When set, it is passed
-                                        as an additional parameter to the metrics
-                                        server for more specific metrics scoping When
-                                        unset, just the metricName will be used to
-                                        gather metrics.
-                                      properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
-                                          items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key
-                                                  that the selector applies to.
-                                                type: string
-                                              operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
-                                          type: object
-                                      type: object
-                                    target:
-                                      description: target is the described Kubernetes
-                                        object.
+                                    describedObject:
+                                      description: CrossVersionObjectReference contains
+                                        enough information to let you identify the
+                                        referred resource.
                                       properties:
                                         apiVersion:
                                           description: API version of the referent
@@ -420,18 +388,120 @@ spec:
                                       - kind
                                       - name
                                       type: object
-                                    targetValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: targetValue is the target value
-                                        of the metric (as a quantity).
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                    metric:
+                                      description: metric identifies the target metric
+                                        by name and selector
+                                      properties:
+                                        name:
+                                          description: name is the name of the given
+                                            metric
+                                          type: string
+                                        selector:
+                                          description: selector is the string-encoded
+                                            form of a standard kubernetes label selector
+                                            for the given metric When set, it is passed
+                                            as an additional parameter to the metrics
+                                            server for more specific metrics scoping.
+                                            When unset, just the metricName will be
+                                            used to gather metrics.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      description: target specifies the target value
+                                        for the given metric
+                                      properties:
+                                        averageUtilization:
+                                          description: averageUtilization is the target
+                                            value of the average of the resource metric
+                                            across all relevant pods, represented
+                                            as a percentage of the requested value
+                                            of the resource for the pods. Currently
+                                            only valid for Resource metric source
+                                            type
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: averageValue is the target
+                                            value of the average of the metric across
+                                            all relevant pods (as a quantity)
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: type represents whether the
+                                            metric type is Utilization, Value, or
+                                            AverageValue
+                                          type: string
+                                        value:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: value is the target value of
+                                            the metric (as a quantity).
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - type
+                                      type: object
                                   required:
-                                  - metricName
+                                  - describedObject
+                                  - metric
                                   - target
-                                  - targetValue
                                   type: object
                                 pods:
                                   description: pods refers to a metric describing
@@ -440,79 +510,119 @@ spec:
                                     will be averaged together before being compared
                                     to the target value.
                                   properties:
-                                    metricName:
-                                      description: metricName is the name of the metric
-                                        in question
-                                      type: string
-                                    selector:
-                                      description: selector is the string-encoded
-                                        form of a standard kubernetes label selector
-                                        for the given metric When set, it is passed
-                                        as an additional parameter to the metrics
-                                        server for more specific metrics scoping When
-                                        unset, just the metricName will be used to
-                                        gather metrics.
+                                    metric:
+                                      description: metric identifies the target metric
+                                        by name and selector
                                       properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
-                                          items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key
-                                                  that the selector applies to.
+                                        name:
+                                          description: name is the name of the given
+                                            metric
+                                          type: string
+                                        selector:
+                                          description: selector is the string-encoded
+                                            form of a standard kubernetes label selector
+                                            for the given metric When set, it is passed
+                                            as an additional parameter to the metrics
+                                            server for more specific metrics scoping.
+                                            When unset, just the metricName will be
+                                            used to gather metrics.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
                                                 type: string
-                                              operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
                                           type: object
+                                      required:
+                                      - name
                                       type: object
-                                    targetAverageValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: targetAverageValue is the target
-                                        value of the average of the metric across
-                                        all relevant pods (as a quantity)
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                    target:
+                                      description: target specifies the target value
+                                        for the given metric
+                                      properties:
+                                        averageUtilization:
+                                          description: averageUtilization is the target
+                                            value of the average of the resource metric
+                                            across all relevant pods, represented
+                                            as a percentage of the requested value
+                                            of the resource for the pods. Currently
+                                            only valid for Resource metric source
+                                            type
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: averageValue is the target
+                                            value of the average of the metric across
+                                            all relevant pods (as a quantity)
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: type represents whether the
+                                            metric type is Utilization, Value, or
+                                            AverageValue
+                                          type: string
+                                        value:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: value is the target value of
+                                            the metric (as a quantity).
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - type
+                                      type: object
                                   required:
-                                  - metricName
-                                  - targetAverageValue
+                                  - metric
+                                  - target
                                   type: object
                                 resource:
                                   description: resource refers to a resource metric
@@ -527,27 +637,48 @@ spec:
                                       description: name is the name of the resource
                                         in question.
                                       type: string
-                                    targetAverageUtilization:
-                                      description: targetAverageUtilization is the
-                                        target value of the average of the resource
-                                        metric across all relevant pods, represented
-                                        as a percentage of the requested value of
-                                        the resource for the pods.
-                                      format: int32
-                                      type: integer
-                                    targetAverageValue:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: targetAverageValue is the target
-                                        value of the average of the resource metric
-                                        across all relevant pods, as a raw value (instead
-                                        of as a percentage of the request), similar
-                                        to the "pods" metric source type.
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                    target:
+                                      description: target specifies the target value
+                                        for the given metric
+                                      properties:
+                                        averageUtilization:
+                                          description: averageUtilization is the target
+                                            value of the average of the resource metric
+                                            across all relevant pods, represented
+                                            as a percentage of the requested value
+                                            of the resource for the pods. Currently
+                                            only valid for Resource metric source
+                                            type
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: averageValue is the target
+                                            value of the average of the metric across
+                                            all relevant pods (as a quantity)
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: type represents whether the
+                                            metric type is Utilization, Value, or
+                                            AverageValue
+                                          type: string
+                                        value:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: value is the target value of
+                                            the metric (as a quantity).
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - type
+                                      type: object
                                   required:
                                   - name
+                                  - target
                                   type: object
                                 type:
                                   description: type is the type of metric source.  It
@@ -1287,9 +1418,3 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/controllers/controller_ref_manager.go
+++ b/controllers/controller_ref_manager.go
@@ -29,7 +29,7 @@ import (
 
 	//"github.com/gardener/hvpa-controller/api/v1alpha1"
 
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -187,12 +187,12 @@ func NewHvpaControllerRefManager(
 //
 // If the error is nil, either the reconciliation succeeded, or no
 // reconciliation was necessary. The list of Hpas that you now own is returned.
-func (m *HvpaControllerRefManager) ClaimHpas(hpas *autoscaling.HorizontalPodAutoscalerList, filters ...func(*autoscaling.HorizontalPodAutoscaler) bool) ([]*autoscaling.HorizontalPodAutoscaler, error) {
-	var claimed []*autoscaling.HorizontalPodAutoscaler
+func (m *HvpaControllerRefManager) ClaimHpas(hpas *autoscalingv2beta2.HorizontalPodAutoscalerList, filters ...func(*autoscalingv2beta2.HorizontalPodAutoscaler) bool) ([]*autoscalingv2beta2.HorizontalPodAutoscaler, error) {
+	var claimed []*autoscalingv2beta2.HorizontalPodAutoscaler
 	var errlist []error
 
 	match := func(obj metav1.Object) bool {
-		hpa := obj.(*autoscaling.HorizontalPodAutoscaler)
+		hpa := obj.(*autoscalingv2beta2.HorizontalPodAutoscaler)
 		// Check selector first so filters only run on potentially matching Hpas.
 		if !m.Selector.Matches(labels.Set(hpa.Labels)) {
 			return false
@@ -206,10 +206,10 @@ func (m *HvpaControllerRefManager) ClaimHpas(hpas *autoscaling.HorizontalPodAuto
 	}
 
 	adopt := func(obj metav1.Object) error {
-		return m.AdoptHpa(obj.(*autoscaling.HorizontalPodAutoscaler))
+		return m.AdoptHpa(obj.(*autoscalingv2beta2.HorizontalPodAutoscaler))
 	}
 	release := func(obj metav1.Object) error {
-		return m.ReleaseHpa(obj.(*autoscaling.HorizontalPodAutoscaler))
+		return m.ReleaseHpa(obj.(*autoscalingv2beta2.HorizontalPodAutoscaler))
 	}
 
 	for k := range hpas.Items {
@@ -284,7 +284,7 @@ func (m *HvpaControllerRefManager) ClaimVpas(vpas *vpa_api.VerticalPodAutoscaler
 
 // AdoptHpa sends a patch to take control of the Hpa. It returns the error if
 // the patching fails.
-func (m *HvpaControllerRefManager) AdoptHpa(hpa *autoscaling.HorizontalPodAutoscaler) error {
+func (m *HvpaControllerRefManager) AdoptHpa(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) error {
 	if err := m.CanAdopt(); err != nil {
 		return fmt.Errorf("can't adopt hpa %v/%v (%v): %v", hpa.Namespace, hpa.Name, hpa.UID, err)
 	}
@@ -301,7 +301,7 @@ func (m *HvpaControllerRefManager) AdoptHpa(hpa *autoscaling.HorizontalPodAutosc
 
 // ReleaseHpa sends a patch to free the Hpa from the control of the controller.
 // It returns the error if the patching fails. 404 and 422 errors are ignored.
-func (m *HvpaControllerRefManager) ReleaseHpa(hpa *autoscaling.HorizontalPodAutoscaler) error {
+func (m *HvpaControllerRefManager) ReleaseHpa(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) error {
 	log.V(4).Info("ReleaseHpa()", "HPA", hpa.Namespace+"/"+hpa.Name, "controller", m.controllerKind.String(), "controller name", m.Controller.GetName())
 
 	hpaClone := hpa.DeepCopy()

--- a/controllers/controller_ref_manager.go
+++ b/controllers/controller_ref_manager.go
@@ -64,8 +64,8 @@ func (m *BaseControllerRefManager) CanAdopt() error {
 // ClaimObject tries to take ownership of an object for this controller.
 //
 // It will reconcile the following:
-//   * Adopt orphans if the match function returns true.
-//   * Release owned objects if the match function returns false.
+//   - Adopt orphans if the match function returns true.
+//   - Release owned objects if the match function returns false.
 //
 // A non-nil error is returned if some form of reconciliation was attempted and
 // failed. Usually, controllers should try again later in case reconciliation
@@ -151,8 +151,9 @@ type HvpaControllerRefManager struct {
 // If CanAdopt() returns a non-nil error, all adoptions will fail.
 //
 // NOTE: Once CanAdopt() is called, it will not be called again by the same
-//       HvpaControllerRefManager HPA/VPA. Create a new HPA/VPA if it makes
-//       sense to check CanAdopt() again (e.g. in a different sync pass).
+//
+//	HvpaControllerRefManager HPA/VPA. Create a new HPA/VPA if it makes
+//	sense to check CanAdopt() again (e.g. in a different sync pass).
 func NewHvpaControllerRefManager(
 	reconciler *HvpaReconciler,
 	controller metav1.Object,
@@ -174,8 +175,8 @@ func NewHvpaControllerRefManager(
 // ClaimHpas tries to take ownership of a list of Hpas.
 //
 // It will reconcile the following:
-//   * Adopt orphans if the selector matches.
-//   * Release owned objects if the selector no longer matches.
+//   - Adopt orphans if the selector matches.
+//   - Release owned objects if the selector no longer matches.
 //
 // Optional: If one or more filters are specified, a Hpa will only be claimed if
 // all filters return true.
@@ -229,8 +230,8 @@ func (m *HvpaControllerRefManager) ClaimHpas(hpas *autoscaling.HorizontalPodAuto
 // ClaimVpas tries to take ownership of a list of Vpas.
 //
 // It will reconcile the following:
-//   * Adopt orphans if the selector matches.
-//   * Release owned objects if the selector no longer matches.
+//   - Adopt orphans if the selector matches.
+//   - Release owned objects if the selector no longer matches.
 //
 // Optional: If one or more filters are specified, a Vpa will only be claimed if
 // all filters return true.

--- a/controllers/hpa_util.go
+++ b/controllers/hpa_util.go
@@ -31,7 +31,8 @@ import (
 )
 
 // TODO: use client library instead when it starts to support update retries
-//       see https://github.com/kubernetes/kubernetes/issues/21479
+//
+//	see https://github.com/kubernetes/kubernetes/issues/21479
 type updateHpaFunc func(hpa *autoscaling.HorizontalPodAutoscaler)
 
 func (r *HvpaReconciler) claimHpas(hvpa *autoscalingv1alpha1.Hvpa, selector labels.Selector, hpas *autoscaling.HorizontalPodAutoscalerList) ([]*autoscaling.HorizontalPodAutoscaler, error) {

--- a/controllers/hpa_util.go
+++ b/controllers/hpa_util.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 
 	autoscalingv1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,9 +33,9 @@ import (
 // TODO: use client library instead when it starts to support update retries
 //
 //	see https://github.com/kubernetes/kubernetes/issues/21479
-type updateHpaFunc func(hpa *autoscaling.HorizontalPodAutoscaler)
+type updateHpaFunc func(hpa *autoscalingv2beta2.HorizontalPodAutoscaler)
 
-func (r *HvpaReconciler) claimHpas(hvpa *autoscalingv1alpha1.Hvpa, selector labels.Selector, hpas *autoscaling.HorizontalPodAutoscalerList) ([]*autoscaling.HorizontalPodAutoscaler, error) {
+func (r *HvpaReconciler) claimHpas(hvpa *autoscalingv1alpha1.Hvpa, selector labels.Selector, hpas *autoscalingv2beta2.HorizontalPodAutoscalerList) ([]*autoscalingv2beta2.HorizontalPodAutoscaler, error) {
 	// If any adoptions are attempted, we should first recheck for deletion with
 	// an uncached quorum read sometime after listing Machines (see #42639).
 	canAdoptFunc := RecheckDeletionTimestamp(func() (metav1.Object, error) {
@@ -54,7 +54,7 @@ func (r *HvpaReconciler) claimHpas(hvpa *autoscalingv1alpha1.Hvpa, selector labe
 }
 
 // The returned bool value can be used to tell if the hpa is actually updated.
-func hpaSpecNeedChange(hvpa *autoscalingv1alpha1.Hvpa, hpa *autoscaling.HorizontalPodAutoscaler) bool {
+func hpaSpecNeedChange(hvpa *autoscalingv1alpha1.Hvpa, hpa *autoscalingv2beta2.HorizontalPodAutoscaler) bool {
 	return *hvpa.Spec.Hpa.Template.Spec.MinReplicas != *hpa.Spec.MinReplicas ||
 		hvpa.Spec.Hpa.Template.Spec.MaxReplicas != hpa.Spec.MaxReplicas ||
 		!reflect.DeepEqual(hvpa.Spec.Hpa.Template.Spec.Metrics, hpa.Spec.Metrics) ||
@@ -62,8 +62,8 @@ func hpaSpecNeedChange(hvpa *autoscalingv1alpha1.Hvpa, hpa *autoscaling.Horizont
 }
 
 // UpdateHpaWithRetries updates a hpa with given applyUpdate function. Note that hpa not found error is ignored.
-func (r *HvpaReconciler) UpdateHpaWithRetries(namespace, name string, applyUpdate updateHpaFunc) (*autoscaling.HorizontalPodAutoscaler, error) {
-	hpa := &autoscaling.HorizontalPodAutoscaler{}
+func (r *HvpaReconciler) UpdateHpaWithRetries(namespace, name string, applyUpdate updateHpaFunc) (*autoscalingv2beta2.HorizontalPodAutoscaler, error) {
+	hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var err error
@@ -86,11 +86,11 @@ func (r *HvpaReconciler) UpdateHpaWithRetries(namespace, name string, applyUpdat
 	return hpa, retryErr
 }
 
-func (r *HvpaReconciler) syncHpaSpec(hpaList []*autoscaling.HorizontalPodAutoscaler, hvpa *autoscalingv1alpha1.Hvpa) error {
+func (r *HvpaReconciler) syncHpaSpec(hpaList []*autoscalingv2beta2.HorizontalPodAutoscaler, hvpa *autoscalingv1alpha1.Hvpa) error {
 	for _, hpa := range hpaList {
 		if hpaChanged := hpaSpecNeedChange(hvpa, hpa); hpaChanged {
 			_, err := r.UpdateHpaWithRetries(hpa.Namespace, hpa.Name,
-				func(hpaToUpdate *autoscaling.HorizontalPodAutoscaler) {
+				func(hpaToUpdate *autoscalingv2beta2.HorizontalPodAutoscaler) {
 					hpaToUpdate.Spec.MinReplicas = hvpa.Spec.Hpa.Template.Spec.MinReplicas
 					hpaToUpdate.Spec.MaxReplicas = hvpa.Spec.Hpa.Template.Spec.MaxReplicas
 					hpaToUpdate.Spec.Metrics = hvpa.Spec.Hpa.Template.Spec.Metrics
@@ -105,7 +105,7 @@ func (r *HvpaReconciler) syncHpaSpec(hpaList []*autoscaling.HorizontalPodAutosca
 	return nil
 }
 
-func getHpaFromHvpa(hvpa *autoscalingv1alpha1.Hvpa) (*autoscaling.HorizontalPodAutoscaler, error) {
+func getHpaFromHvpa(hvpa *autoscalingv1alpha1.Hvpa) (*autoscalingv2beta2.HorizontalPodAutoscaler, error) {
 	metadata := hvpa.Spec.Hpa.Template.ObjectMeta.DeepCopy()
 
 	if ownerRef := metadata.GetOwnerReferences(); len(ownerRef) != 0 {
@@ -125,9 +125,9 @@ func getHpaFromHvpa(hvpa *autoscalingv1alpha1.Hvpa) (*autoscaling.HorizontalPodA
 	metadata.SetGenerateName(hvpa.Name + "-")
 	metadata.SetNamespace(hvpa.Namespace)
 
-	return &autoscaling.HorizontalPodAutoscaler{
+	return &autoscalingv2beta2.HorizontalPodAutoscaler{
 		ObjectMeta: *metadata,
-		Spec: autoscaling.HorizontalPodAutoscalerSpec{
+		Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
 			MaxReplicas:    hvpa.Spec.Hpa.Template.Spec.MaxReplicas,
 			MinReplicas:    hvpa.Spec.Hpa.Template.Spec.MinReplicas,
 			ScaleTargetRef: *hvpa.Spec.TargetRef.DeepCopy(),

--- a/controllers/hpa_util_test.go
+++ b/controllers/hpa_util_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -47,7 +47,7 @@ var _ = Describe("#Adopt HPA", func() {
 
 			hasSingleChildFn := func() error {
 				num := 0
-				objList := &autoscaling.HorizontalPodAutoscalerList{}
+				objList := &autoscalingv2beta2.HorizontalPodAutoscalerList{}
 				if err := c.List(context.TODO(), objList); err != nil {
 					return err
 				}
@@ -90,7 +90,7 @@ var _ = Describe("#Adopt HPA", func() {
 
 			// Eventually the owner ref from HPA should be removed by the HVPA controller
 			Eventually(func() error {
-				hpaList := &autoscaling.HorizontalPodAutoscalerList{}
+				hpaList := &autoscalingv2beta2.HorizontalPodAutoscalerList{}
 				c.List(context.TODO(), hpaList, client.MatchingLabels(label))
 				for _, obj := range hpaList.Items {
 					for _, ref := range obj.GetOwnerReferences() {

--- a/controllers/hvpa_controller_test.go
+++ b/controllers/hvpa_controller_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,8 +138,8 @@ var _ = Describe("#TestReconcile", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer c.Delete(context.TODO(), instance)
 
-			hpaList := &autoscaling.HorizontalPodAutoscalerList{}
-			hpa := &autoscaling.HorizontalPodAutoscaler{}
+			hpaList := &autoscalingv2beta2.HorizontalPodAutoscalerList{}
+			hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
 			Eventually(func() error {
 				num := 0
 				c.List(context.TODO(), hpaList)
@@ -246,7 +246,7 @@ var _ = Describe("#TestReconcile", func() {
 	Describe("#ScaleTests", func() {
 		type setup struct {
 			hvpa      *autoscalingv1alpha1.Hvpa
-			hpaStatus *autoscaling.HorizontalPodAutoscalerStatus
+			hpaStatus *autoscalingv2beta2.HorizontalPodAutoscalerStatus
 			vpaStatus *vpa_api.VerticalPodAutoscalerStatus
 			target    *appsv1.Deployment
 			vpaWeight int32
@@ -345,9 +345,9 @@ var _ = Describe("#TestReconcile", func() {
 				setup: setup{
 					hvpa: newHvpa("hvpa-2", target.GetName(), "label-2", minChange),
 					hpaStatus: newHpaStatus(
-						2, 3, []autoscaling.HorizontalPodAutoscalerCondition{
+						2, 3, []autoscalingv2beta2.HorizontalPodAutoscalerCondition{
 							{
-								Type:   autoscaling.ScalingLimited,
+								Type:   autoscalingv2beta2.ScalingLimited,
 								Status: v1.ConditionTrue,
 							},
 						}),
@@ -373,9 +373,9 @@ var _ = Describe("#TestReconcile", func() {
 				setup: setup{
 					hvpa: newHvpa("hvpa-2", target.GetName(), "label-2", minChange),
 					hpaStatus: newHpaStatus(
-						2, 3, []autoscaling.HorizontalPodAutoscalerCondition{
+						2, 3, []autoscalingv2beta2.HorizontalPodAutoscalerCondition{
 							{
-								Type:   autoscaling.ScalingLimited,
+								Type:   autoscalingv2beta2.ScalingLimited,
 								Status: v1.ConditionTrue,
 							},
 						}),
@@ -398,9 +398,9 @@ var _ = Describe("#TestReconcile", func() {
 				setup: setup{
 					hvpa: newHvpa("hvpa-2", target.GetName(), "label-2", minChange),
 					hpaStatus: newHpaStatus(
-						2, 1, []autoscaling.HorizontalPodAutoscalerCondition{
+						2, 1, []autoscalingv2beta2.HorizontalPodAutoscalerCondition{
 							{
-								Type:   autoscaling.ScalingLimited,
+								Type:   autoscalingv2beta2.ScalingLimited,
 								Status: v1.ConditionFalse,
 							},
 						}),
@@ -430,9 +430,9 @@ var _ = Describe("#TestReconcile", func() {
 				setup: setup{
 					hvpa: newHvpa("hvpa-2", target.GetName(), "label-2", minChange),
 					hpaStatus: newHpaStatus(
-						2, 3, []autoscaling.HorizontalPodAutoscalerCondition{
+						2, 3, []autoscalingv2beta2.HorizontalPodAutoscalerCondition{
 							{
-								Type:   autoscaling.ScalingLimited,
+								Type:   autoscalingv2beta2.ScalingLimited,
 								Status: v1.ConditionTrue,
 							},
 						}),
@@ -463,9 +463,9 @@ var _ = Describe("#TestReconcile", func() {
 				setup: setup{
 					hvpa: newHvpa("hvpa-2", target.GetName(), "label-2", minChange),
 					hpaStatus: newHpaStatus(
-						2, 3, []autoscaling.HorizontalPodAutoscalerCondition{
+						2, 3, []autoscalingv2beta2.HorizontalPodAutoscalerCondition{
 							{
-								Type:   autoscaling.ScalingLimited,
+								Type:   autoscalingv2beta2.ScalingLimited,
 								Status: v1.ConditionFalse,
 							},
 						}),
@@ -488,9 +488,9 @@ var _ = Describe("#TestReconcile", func() {
 				setup: setup{
 					hvpa: newHvpa("hvpa-2", target.GetName(), "label-2", minChange),
 					hpaStatus: newHpaStatus(
-						2, 3, []autoscaling.HorizontalPodAutoscalerCondition{
+						2, 3, []autoscalingv2beta2.HorizontalPodAutoscalerCondition{
 							{
-								Type:   autoscaling.ScalingLimited,
+								Type:   autoscalingv2beta2.ScalingLimited,
 								Status: v1.ConditionTrue,
 							},
 						}),
@@ -516,9 +516,9 @@ var _ = Describe("#TestReconcile", func() {
 				setup: setup{
 					hvpa: newHvpa("hvpa-2", target.GetName(), "label-2", minChange),
 					hpaStatus: newHpaStatus(
-						2, 3, []autoscaling.HorizontalPodAutoscalerCondition{
+						2, 3, []autoscalingv2beta2.HorizontalPodAutoscalerCondition{
 							{
-								Type:   autoscaling.ScalingLimited,
+								Type:   autoscalingv2beta2.ScalingLimited,
 								Status: v1.ConditionTrue,
 							},
 						}),
@@ -551,9 +551,9 @@ var _ = Describe("#TestReconcile", func() {
 				setup: setup{
 					hvpa: newHvpa("hvpa-2", target.GetName(), "label-2", minChange),
 					hpaStatus: newHpaStatus(
-						3, 3, []autoscaling.HorizontalPodAutoscalerCondition{
+						3, 3, []autoscalingv2beta2.HorizontalPodAutoscalerCondition{
 							{
-								Type:   autoscaling.ScalingLimited,
+								Type:   autoscalingv2beta2.ScalingLimited,
 								Status: v1.ConditionTrue,
 							},
 						}),
@@ -587,9 +587,9 @@ var _ = Describe("#TestReconcile", func() {
 				setup: setup{
 					hvpa: newHvpa("hvpa-2", target.GetName(), "label-2", minChange),
 					hpaStatus: newHpaStatus(
-						2, 3, []autoscaling.HorizontalPodAutoscalerCondition{
+						2, 3, []autoscalingv2beta2.HorizontalPodAutoscalerCondition{
 							{
-								Type:   autoscaling.ScalingLimited,
+								Type:   autoscalingv2beta2.ScalingLimited,
 								Status: v1.ConditionTrue,
 							},
 						}),

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -26,7 +26,7 @@ import (
 
 	autoscalingv1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -156,7 +156,7 @@ func newHvpa(name, target, labelVal string, minChange autoscalingv1alpha1.ScaleP
 			},
 		},
 		Spec: autoscalingv1alpha1.HvpaSpec{
-			TargetRef: &autoscaling.CrossVersionObjectReference{
+			TargetRef: &autoscalingv2beta2.CrossVersionObjectReference{
 				Kind:       "Deployment",
 				Name:       target,
 				APIVersion: "apps/v1",
@@ -190,12 +190,15 @@ func newHvpa(name, target, labelVal string, minChange autoscalingv1alpha1.ScaleP
 					Spec: autoscalingv1alpha1.HpaTemplateSpec{
 						MinReplicas: &replica,
 						MaxReplicas: 3,
-						Metrics: []autoscaling.MetricSpec{
-							autoscaling.MetricSpec{
-								Type: autoscaling.ResourceMetricSourceType,
-								Resource: &autoscaling.ResourceMetricSource{
-									Name:                     v1.ResourceCPU,
-									TargetAverageUtilization: &util,
+						Metrics: []autoscalingv2beta2.MetricSpec{
+							{
+								Type: autoscalingv2beta2.ResourceMetricSourceType,
+								Resource: &autoscalingv2beta2.ResourceMetricSource{
+									Name: v1.ResourceCPU,
+									Target: autoscalingv2beta2.MetricTarget{
+										Type:               autoscalingv2beta2.AverageValueMetricType,
+										AverageUtilization: &util,
+									},
 								},
 							},
 						},
@@ -249,8 +252,8 @@ func newHvpa(name, target, labelVal string, minChange autoscalingv1alpha1.ScaleP
 	return instance
 }
 
-func newHpaStatus(currentReplicas, desiredReplicas int32, conditions []autoscaling.HorizontalPodAutoscalerCondition) *autoscaling.HorizontalPodAutoscalerStatus {
-	return &autoscaling.HorizontalPodAutoscalerStatus{
+func newHpaStatus(currentReplicas, desiredReplicas int32, conditions []autoscalingv2beta2.HorizontalPodAutoscalerCondition) *autoscalingv2beta2.HorizontalPodAutoscalerStatus {
+	return &autoscalingv2beta2.HorizontalPodAutoscalerStatus{
 		CurrentReplicas: currentReplicas,
 		DesiredReplicas: desiredReplicas,
 		Conditions:      conditions,

--- a/controllers/vpa_util.go
+++ b/controllers/vpa_util.go
@@ -32,7 +32,8 @@ import (
 )
 
 // TODO: use client library instead when it starts to support update retries
-//       see https://github.com/kubernetes/kubernetes/issues/21479
+//
+//	see https://github.com/kubernetes/kubernetes/issues/21479
 type updateVpaFunc func(vpa *vpa_api.VerticalPodAutoscaler)
 
 func (r *HvpaReconciler) claimVpas(hvpa *autoscalingv1alpha1.Hvpa, selector labels.Selector, vpas *vpa_api.VerticalPodAutoscalerList) ([]*vpa_api.VerticalPodAutoscaler, error) {

--- a/internal/api/v1alpha1/hvpa_types_test.go
+++ b/internal/api/v1alpha1/hvpa_types_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/onsi/gomega"
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -66,7 +66,7 @@ var _ = Describe("Hvpa", func() {
 					Namespace: "default",
 				},
 				Spec: HvpaSpec{
-					TargetRef: &autoscaling.CrossVersionObjectReference{},
+					TargetRef: &autoscalingv2beta2.CrossVersionObjectReference{},
 					Hpa: HpaSpec{
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{

--- a/utils/timewindow_test.go
+++ b/utils/timewindow_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/utils/utils_suite_test.go
+++ b/utils/utils_suite_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/vendor/github.com/gardener/hvpa-controller/api/v1alpha1/hvpa_types.go
+++ b/vendor/github.com/gardener/hvpa-controller/api/v1alpha1/hvpa_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpa_api "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 )
@@ -83,7 +83,7 @@ type HpaTemplateSpec struct {
 	// more information about how each type of metric must respond.
 	// If not set, the default metric will be set to 80% average CPU utilization.
 	// +optional
-	Metrics []autoscaling.MetricSpec `json:"metrics,omitempty" protobuf:"bytes,3,rep,name=metrics"`
+	Metrics []autoscalingv2beta2.MetricSpec `json:"metrics,omitempty" protobuf:"bytes,3,rep,name=metrics"`
 }
 
 // WeightBasedScalingInterval defines the interval of replica counts in which VpaWeight is applied to VPA scaling
@@ -218,7 +218,7 @@ type HvpaSpec struct {
 	WeightBasedScalingIntervals []WeightBasedScalingInterval `json:"weightBasedScalingIntervals,omitempty"`
 
 	// TargetRef points to the controller managing the set of pods for the autoscaler to control
-	TargetRef *autoscaling.CrossVersionObjectReference `json:"targetRef"`
+	TargetRef *autoscalingv2beta2.CrossVersionObjectReference `json:"targetRef"`
 
 	// MaintenanceTimeWindow contains information about the time window for maintenance operations.
 	// +optional

--- a/vendor/github.com/gardener/hvpa-controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/hvpa-controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -134,7 +134,7 @@ func (in *HpaTemplateSpec) DeepCopyInto(out *HpaTemplateSpec) {
 	}
 	if in.Metrics != nil {
 		in, out := &in.Metrics, &out.Metrics
-		*out = make([]v2beta1.MetricSpec, len(*in))
+		*out = make([]v2beta2.MetricSpec, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -227,7 +227,7 @@ func (in *HvpaSpec) DeepCopyInto(out *HvpaSpec) {
 	}
 	if in.TargetRef != nil {
 		in, out := &in.TargetRef, &out.TargetRef
-		*out = new(v2beta1.CrossVersionObjectReference)
+		*out = new(v2beta2.CrossVersionObjectReference)
 		**out = **in
 	}
 	if in.MaintenanceTimeWindow != nil {


### PR DESCRIPTION
**What this PR does / why we need it**
Update to `k8s.io/autoscaling/v2beta2`, because `v2beta1` is no longer served in k8s 1.25. 

Version `k8s.io/autoscaling/v2beta2` was introduced with k8s 1.12, so all of our clusters support this. I didn't immediately jump to  `k8s.io/autoscaling/v2`, because it is only available from k8s 1.23 (and we still have clusters with versions smaller than that). When `k8s.io/autoscaling/v2beta2` will stop being served in k8s 1.26, we can switch to `k8s.io/autoscaling/v2` without any content changes - it is identical to `k8s.io/autoscaling/v2beta2`.

**Which issue(s) this PR fixes**:
Fixes #104

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Update to k8s.io/autoscaling/v2beta2, such that this HVPA version works with k8s v1.12-v1.25
```
