### PR TITLE
Bump pipeline golang to 1.18

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,9 +22,9 @@ hvpa-controller:
                 source: ~
     steps:
       check:
-        image: 'golang:1.15.3'
+        image: 'golang:1.18.6'
       integration_test:
-        image: 'golang:1.15.3'
+        image: 'golang:1.18.6'
 
   jobs:
     head-update:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps golang version of pipeline to 1.18 to enable follow up migration of codebase to same version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
