### PR TITLE
Migrate project to kubebuilder v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,23 @@ IMAGE_TAG           := $(VERSION)
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_REPOSITORY):$(IMAGE_TAG)
 
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+KUSTOMIZE ?= $(LOCALBIN)/kustomize
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+
+## Tool Versions
+KUSTOMIZE_VERSION ?= v3.8.7
+CONTROLLER_TOOLS_VERSION ?= v0.9.2
+
+KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -102,21 +119,6 @@ revendor:
 
 ##@ Build Dependencies
 
-## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
-	mkdir -p $(LOCALBIN)
-
-## Tool Binaries
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-ENVTEST ?= $(LOCALBIN)/setup-envtest
-
-## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.9.2
-
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,13 @@ include hack/tools.mk
 
 all: manager
 
-# Run tests
-test: generate fmt vet
-	@env GO111MODULE=on GOFLAGS=-mod=vendor go test ./internal/... ./controllers/... ./utils/... -coverprofile cover.out
+# Setting SHELL to bash allows bash commands to be executed by recipes.
+# Options are set to exit when a recipe line exits non-zero or a piped command fails.
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+
+test: envtest manifests generate fmt vet ## Run tests.
+	source <($(LOCALBIN)/setup-envtest use -p env 1.24.2); go test ./internal/... ./controllers/... ./utils/... -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet
@@ -96,12 +100,34 @@ revendor:
 	@env GO111MODULE=on go mod tidy
 	@env GO111MODULE=on go mod vendor
 
-# find or download controller-gen
-# download controller-gen if necessary
-controller-gen:
-ifeq (, $(shell which controller-gen))
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
-endif
+##@ Build Dependencies
+
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+KUSTOMIZE ?= $(LOCALBIN)/kustomize
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+
+## Tool Versions
+KUSTOMIZE_VERSION ?= v3.8.7
+CONTROLLER_TOOLS_VERSION ?= v0.9.2
+
+KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE): $(LOCALBIN)
+	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN): $(LOCALBIN)
+	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest

--- a/PROJECT
+++ b/PROJECT
@@ -1,7 +1,16 @@
-version: "2"
+projectName: hvpa-controller
+layout:
+- go.kubebuilder.io/v3
 domain: k8s.io
 repo: github.com/gardener/hvpa-controller
 resources:
 - group: autoscaling
-  version: v1alpha1
   kind: Hvpa
+  version: v1alpha1
+  controller: true
+  domain: k8s.io
+  path: github.com/gardener/hvpa-controller/api/v1alpha1
+  api:
+    crdVersion: v1
+    namespaced: true
+version: "3"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -21,5 +21,5 @@ spec:
           name: https
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"

--- a/main.go
+++ b/main.go
@@ -50,8 +50,8 @@ func main() {
 		enableLeaderElection  bool
 		enableDetailedMetrics bool
 	)
-	flag.StringVar(&metricsAddr, "metrics-addr", ":9569", "The address the metric endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":9569", "The address the metric endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableDetailedMetrics, "enable-detailed-metrics", false,
 		"Enable detailed per HVPA resource metrics. This could significantly increase the cardinality of the metrics.")

--- a/main.go
+++ b/main.go
@@ -20,13 +20,15 @@ import (
 	"flag"
 	"os"
 
-	autoscalingv1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
-	"github.com/gardener/hvpa-controller/controllers"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	klogv2 "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	autoscalingv1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
+	"github.com/gardener/hvpa-controller/controllers"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -36,9 +38,9 @@ var (
 )
 
 func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(autoscalingv1alpha1.AddToScheme(scheme))
 
-	_ = autoscalingv1alpha1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Migrate the project to kubebuilder v3 according to the [official migration docs](https://book.kubebuilder.io/migration/manually_migration_guide_v2_v3.html), such that we can use `kubebuilder` scaffolding to create webhooks and other things.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The parameters `metrics-addr` and `enable-leader-election` have been changed to `metrics-bind-address` and `leader-elect` respectively to be in-line with kubebuilder v3 scaffolding.
```
```other developer
`make test` is adapted to automatically configure envtest to use k8s 1.24.2 binaries
```
```other developer
Necessary binaries, such as `controller-gen`, `kustomize` and `setup-envtest` are automatically downloaded and installed into `./bin`
```
