### PR TITLE
Bump to go 1.19.4

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,9 +22,9 @@ hvpa-controller:
                 source: ~
     steps:
       check:
-        image: 'golang:1.18.6'
+        image: 'golang:1.19.4'
       integration_test:
-        image: 'golang:1.18.6'
+        image: 'golang:1.19.4'
 
   jobs:
     head-update:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18.6 as builder
+FROM golang:1.19.4 as builder
 
 WORKDIR /go/src/github.com/gardener/hvpa-controller
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/hvpa-controller/api
 
-go 1.18
+go 1.19
 
 require (
 	k8s.io/api v0.25.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/hvpa-controller
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gardener/hvpa-controller/api v0.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -30,7 +30,7 @@ github.com/fatih/color
 ## explicit; go 1.16
 github.com/fsnotify/fsnotify
 # github.com/gardener/hvpa-controller/api v0.0.0 => ./api
-## explicit; go 1.18
+## explicit; go 1.19
 github.com/gardener/hvpa-controller/api/v1alpha1
 # github.com/go-logr/logr v1.2.3
 ## explicit; go 1.16


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes security related issues with using go 1.18

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Bumped go to 1.19.4
```
