### PR TITLE
Update go to 1.19.9

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,9 +22,9 @@ hvpa-controller:
                 source: ~
     steps:
       check:
-        image: 'golang:1.19.7'
+        image: 'golang:1.19.9'
       integration_test:
-        image: 'golang:1.19.7'
+        image: 'golang:1.19.9'
 
   jobs:
     head-update:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.7 as builder
+FROM golang:1.19.9 as builder
 
 WORKDIR /go/src/github.com/gardener/hvpa-controller
 # Copy the Go Modules manifests


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates go to 1.19.9 to pull in recent security fixes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated go to 1.19.9
```
