### PR TITLE
Fix HPA MetricSpec conversion

### DIFF
--- a/controllers/hpa_util.go
+++ b/controllers/hpa_util.go
@@ -98,7 +98,7 @@ func (r *HvpaReconciler) Convert_v2_HPA_to_v2beta1(in *autoscalingv2.HorizontalP
 func (r *HvpaReconciler) Convert_v2beta1_MetricSpec_to_v2(err error, in autoscaling.MetricSpec) (*autoscalingv2.MetricSpec, error) {
 	out := &autoscalingv2.MetricSpec{}
 	internalHpaMetricSpec := &kubernetesinternalautoscaling.MetricSpec{}
-	err = r.Scheme.Convert(in, internalHpaMetricSpec, context.TODO())
+	err = r.Scheme.Convert(&in, internalHpaMetricSpec, context.TODO())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When the HVPA controller finds that the HPA Spec had changed, it tries to sync the existing HPA with the new information from the HVPA object. If we have k8s >= 1.23 with the `autoscaling.k8s.io/v2` API available, a conversion for the `MetricSpec` is necessary, since this has incompatibly changed. We're re-using the existing conversion implementations from k/k inside the scheme, and those seem to take a `MetricSpec` _pointer_ instead of an object.
Since the HPA spec is seldomly changed and we didn't have and envtest for it, we catched this only now.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug that caused HVPA reconciliation to fail with `expected pointer, but got v2beta1.MetricSpec type` when the HPA spec had changed.
```
