### PR TITLE
Update go to 1.20.7

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,9 +22,9 @@ hvpa-controller:
                 source: ~
     steps:
       check:
-        image: 'golang:1.19.9'
+        image: 'golang:1.20.7'
       integration_test:
-        image: 'golang:1.19.9'
+        image: 'golang:1.20.7'
 
   jobs:
     head-update:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.9 as builder
+FROM golang:1.20.7 as builder
 
 WORKDIR /go/src/github.com/gardener/hvpa-controller
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/hvpa-controller/api
 
-go 1.19
+go 1.20
 
 require (
 	k8s.io/api v0.25.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/hvpa-controller
 
-go 1.19
+go 1.20
 
 require (
 	github.com/gardener/hvpa-controller/api v0.0.0
@@ -14,6 +14,7 @@ require (
 	k8s.io/client-go v0.25.3
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/kubernetes v1.25.4
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/controller-runtime v0.13.1
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230412185432-fbd6b944a634
 	sigs.k8s.io/controller-tools v0.10.0
@@ -84,7 +85,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -30,7 +30,7 @@ github.com/fatih/color
 ## explicit; go 1.16
 github.com/fsnotify/fsnotify
 # github.com/gardener/hvpa-controller/api v0.0.0 => ./api
-## explicit; go 1.19
+## explicit; go 1.20
 github.com/gardener/hvpa-controller/api/v1alpha1
 # github.com/go-logr/logr v1.2.3
 ## explicit; go 1.16


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates go to 1.20.7 to pull in recent security fixes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated go to 1.20.7
```
