### PR TITLE
switch GCR -> Artifact-Registry 

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,7 +5,8 @@ hvpa-controller:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
-      component_descriptor: ~
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -13,7 +14,7 @@ hvpa-controller:
         - linux/arm64
         dockerimages:
           hvpa-controller:
-            image: 'eu.gcr.io/gardener-project/gardener/hvpa-controller'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/hvpa-controller
             dockerfile: 'Dockerfile'
             inputs:
               repos:
@@ -27,7 +28,9 @@ hvpa-controller:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
     pull-request:
       traits:
@@ -36,6 +39,12 @@ hvpa-controller:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            hvpa-controller:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/hvpa-controller
         release:
           nextversion: 'bump_minor'
           git_tags:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,12 +1,11 @@
 hvpa-controller:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor: ~
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -14,7 +13,6 @@ hvpa-controller:
         - linux/arm64
         dockerimages:
           hvpa-controller:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/hvpa-controller'
             dockerfile: 'Dockerfile'
             inputs:
@@ -49,4 +47,3 @@ hvpa-controller:
             internal_scp_workspace:
               channel_name: 'C017KSLTF4H' # gardener-autoscaling
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@
 
 VERSION             := $(shell cat VERSION)
 PACKAGES            :="$(go list -e ./... | grep -vE '/tmp/|/vendor/')"
-REGISTRY            := eu.gcr.io/gardener-project/gardener
+REGISTRY            := europe-docker.pkg.dev/gardener-project/public
 REPO_ROOT           := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
-IMAGE_REPOSITORY    := $(REGISTRY)/hvpa-controller
+IMAGE_REPOSITORY    := $(REGISTRY)/gardener/hvpa-controller
 IMAGE_TAG           := $(VERSION)
 
 # Image URL to use all building/pushing image targets


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
