### PR TITLE
Bump go to 1.21.9

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,9 +21,9 @@ hvpa-controller:
                 source: ~
     steps:
       check:
-        image: 'golang:1.21.8'
+        image: 'golang:1.21.9'
       integration_test:
-        image: 'golang:1.21.8'
+        image: 'golang:1.21.9'
 
   jobs:
     head-update:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21.8 as builder
+FROM golang:1.21.9 as builder
 
 WORKDIR /go/src/github.com/gardener/hvpa-controller
 # Copy the Go Modules manifests


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump go to 1.21.9 to get newest fixes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update go to 1.21.9
```
